### PR TITLE
Splunk deployer: append - Rule for compatibility with ES

### DIFF
--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -38,7 +38,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         # Before processing MDR data, adding config configuration
         uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
-        name = mdr["name"]
+        name = mdr["name"] + ' - Rule'
         description = mdr["description"]
         mdr_splunk = mdr["configurations"]["splunk"]
         advanced_config = mdr_splunk.pop(
@@ -177,7 +177,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         # Add correlation search setup
         if self.CORRELATION_SEARCHES:
             config["action.correlationsearch.enabled"] = "true"
-            config["action.correlationsearch.label"] = name
+            config["action.correlationsearch.label"] = name + ' - Rule'
             techniques = techniques_resolver(uuid)
             if techniques:
                 config["action.correlationsearch.annotations.mitre_attack"] = ", ".join(

--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -38,6 +38,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         # Before processing MDR data, adding config configuration
         uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
+        # For compatibility with Splunk Enterprise Security post-processing on correlation searches, append " - Rule" to the MDR name
         name = mdr["name"] + ' - Rule'
         description = mdr["description"]
         mdr_splunk = mdr["configurations"]["splunk"]

--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -38,8 +38,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         # Before processing MDR data, adding config configuration
         uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
-        # For compatibility with Splunk Enterprise Security post-processing on correlation searches, append " - Rule" to the MDR name
-        name = mdr["name"] + ' - Rule'
+        name = mdr["name"]
         description = mdr["description"]
         mdr_splunk = mdr["configurations"]["splunk"]
         advanced_config = mdr_splunk.pop(
@@ -178,6 +177,8 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         # Add correlation search setup
         if self.CORRELATION_SEARCHES:
             config["action.correlationsearch.enabled"] = "true"
+            # For compatibility with Splunk Enterprise Security post-processing on
+            # correlation searches, append " - Rule" to the MDR name
             config["action.correlationsearch.label"] = name + ' - Rule'
             techniques = techniques_resolver(uuid)
             if techniques:


### PR DESCRIPTION
### Background
In Splunk Enterprise Security (ES), the risk object normalization and enrichment features — especially those related to assets and identities — rely heavily on data model constraints and naming conventions, particularly in the risk analysis framework.

#### Key Points:
* Risk object normalization happens when ES ingests stash-based lookups, specifically:

        `sourcetype=stash`

        `source ends with - Rule`

* This behavior is coded into the correlation search and enrichment logic, especially in macros, such as:

        `es_notable_enrichment_lookup_generator`

        `risk_normalization macros and the Risk Analysis data model.`

### Recommended Action:
To ensure risk object normalization works properly out of the box, always name your correlation searches with - Rule at the end.  
Example: Multiple Failed Logins - Rule

As this behaviour is specific to Splunk Enterprise Security, the proposal is to modify the Splunk deployer to automatically append the string `- Rule` at deployment time.
