### PR TITLE
fix wiki link to MDR documentation in splunk_metadata.py

### DIFF
--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -38,7 +38,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         # Before processing MDR data, adding config configuration
         uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
-        name = mdr["name"]
+        name = mdr["name"].strip()
         description = mdr["description"]
         mdr_splunk = mdr["configurations"]["splunk"]
         advanced_config = mdr_splunk.pop(
@@ -178,8 +178,10 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         if self.CORRELATION_SEARCHES:
             config["action.correlationsearch.enabled"] = "true"
             # For compatibility with Splunk Enterprise Security post-processing on
-            # correlation searches, append " - Rule" to the MDR name
-            config["action.correlationsearch.label"] = name + ' - Rule'
+            # correlation searches, append " - Rule" to the MDR name itself
+            # and keep original name for correlationsearch label
+            config["action.correlationsearch.label"] = name
+            config["name"] = name + ' - Rule'
             techniques = techniques_resolver(uuid)
             if techniques:
                 config["action.correlationsearch.annotations.mitre_attack"] = ", ".join(
@@ -199,7 +201,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         mdr_config = self.config_mdr(mdr)
 
         # Fetch name for the saved search
-        name: str = mdr["name"].strip()
+        name: str = mdr_config["name"].strip()
         mdr_splunk: dict = mdr["configurations"]["splunk"]
         status: str = mdr_splunk["status"]
         query = create_query(mdr)

--- a/Engines/deployment/splunk_metadata.py
+++ b/Engines/deployment/splunk_metadata.py
@@ -87,9 +87,7 @@ class SplunkMetadataDeploy(SplunkEngineInit, DeployMetadata):
             entry["MDR_response_procedure"] = json.dumps(procedure)
             entry["MDR_attack_technique"] = techniques
             entry["MDR_saw_playbook"] = body.get("response", {}).get("playbook")
-            entry["MDR_documentation"] = self.GITWIKI + body.get("name").replace(
-                " ", "-"
-            ).replace("_", "-")
+            entry["MDR_documentation"] = self.GITWIKI + mdr_uuid
 
             entry = {k: v if v is not None else "" for k, v in entry.items()}
 

--- a/Pipelines/Gitlab/modules/reporting.yml
+++ b/Pipelines/Gitlab/modules/reporting.yml
@@ -2,7 +2,7 @@
   stage: 📝 Reporting
   script:
   - cd $TIDE_CORE_REPO/Engines/framework/
-  - python attack_layer_builder.py
+  - python navigator_layer.py
   - git add -A
   - rm -rf $TIDE_CORE_ACCESS #Delete injected Core
   - if ! git diff-index --quiet HEAD; then


### PR DESCRIPTION
The links to MDR documentation in lookup containing the metadata need to use MDR uuid as wiki page names.