### PR TITLE
Fix attack navigator layer script

### DIFF
--- a/Engines/framework/attack_navigator_layer.py
+++ b/Engines/framework/attack_navigator_layer.py
@@ -65,7 +65,7 @@ def run():
             for v in vectors:
                 for tvm in DataTide.Models.tvm:
                     vec = DataTide.Models.tvm[tvm]
-                    if vec["id"] == v:
+                    if vec.get("metadata",{}).get("uuid") == v:
                         for t in vec["threat"]["att&ck"]:
                             vec_techniques.append(t)
             model_data["techniques"] = vec_techniques

--- a/Pipelines/Gitlab/modules/reporting.yml
+++ b/Pipelines/Gitlab/modules/reporting.yml
@@ -2,7 +2,7 @@
   stage: 📝 Reporting
   script:
   - cd $TIDE_CORE_REPO/Engines/framework/
-  - python navigator_layer.py
+  - python attack_navigator_layer.py
   - git add -A
   - rm -rf $TIDE_CORE_ACCESS #Delete injected Core
   - if ! git diff-index --quiet HEAD; then


### PR DESCRIPTION
this PR includes 2 changes:
- fix the missing key id in Threat Vector model (now vec.get("metadata",{}).get("uuid"))
- rename the script to attack_navigator_layer for clarity