### PR TITLE
Fix rule name for Enterprise Security to end with ' - Rule'

### DIFF
--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -38,7 +38,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         # Before processing MDR data, adding config configuration
         uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
-        name = mdr["name"].strip() + ' - Rule' 
+        name = mdr["name"].strip()
         description = mdr["description"]
         mdr_splunk = mdr["configurations"]["splunk"]
         advanced_config = mdr_splunk.pop(
@@ -179,6 +179,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
             config["action.correlationsearch.enabled"] = "true"
             # For compatibility with Splunk Enterprise Security post-processing on
             # correlation searches, append " - Rule" to the MDR name
+            name += ' - Rule' 
             config["action.correlationsearch.label"] = name
             techniques = techniques_resolver(uuid)
             if techniques:

--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -38,7 +38,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         # Before processing MDR data, adding config configuration
         uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
-        name = mdr["name"]
+        name = mdr["name"].strip() + ' - Rule' 
         description = mdr["description"]
         mdr_splunk = mdr["configurations"]["splunk"]
         advanced_config = mdr_splunk.pop(
@@ -179,7 +179,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
             config["action.correlationsearch.enabled"] = "true"
             # For compatibility with Splunk Enterprise Security post-processing on
             # correlation searches, append " - Rule" to the MDR name
-            config["action.correlationsearch.label"] = name + ' - Rule'
+            config["action.correlationsearch.label"] = name
             techniques = techniques_resolver(uuid)
             if techniques:
                 config["action.correlationsearch.annotations.mitre_attack"] = ", ".join(


### PR DESCRIPTION
For complete compatibility with Splunk Enterprise Security App, the name of deployed correlation searches needs to end with ' - Rule'.
This is related to an under documented normalisation taking place when notable events are created. 

This PR checks if the deployed rule is a correlation search and if yes adds the suffix ' - Rule' to both the saved search name and correlationsearch labels.