### PR TITLE
Update MDR_documentation link to use uuid as wiki page name

### DIFF
--- a/Engines/deployment/splunk_metadata.py
+++ b/Engines/deployment/splunk_metadata.py
@@ -87,9 +87,7 @@ class SplunkMetadataDeploy(SplunkEngineInit, DeployMetadata):
             entry["MDR_response_procedure"] = json.dumps(procedure)
             entry["MDR_attack_technique"] = techniques
             entry["MDR_saw_playbook"] = body.get("response", {}).get("playbook")
-            entry["MDR_documentation"] = self.GITWIKI + body.get("name").replace(
-                " ", "-"
-            ).replace("_", "-")
+            entry["MDR_documentation"] = self.GITWIKI + mdr_uuid
 
             entry = {k: v if v is not None else "" for k, v in entry.items()}
 


### PR DESCRIPTION
The link in column MDR_documentation should point to wiki page that have uuid as name. 
Rest of the path is well configured via TOML files.