### PR TITLE
feat: support multiple wiki targets dynamically

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 100
+          ref: ${{ github.ref }}
 
       - name: Checkout CoreTide
         uses: actions/checkout@v4
@@ -69,6 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          ref: ${{ github.ref }}
 
       - name: Checkout CoreTide
         uses: actions/checkout@v4

--- a/.github/workflows/framework.yml
+++ b/.github/workflows/framework.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 100
+          ref: ${{ github.ref }}
 
       - name: Checkout CoreTide
         uses: actions/checkout@v4

--- a/Configurations/documentation.toml
+++ b/Configurations/documentation.toml
@@ -1,6 +1,3 @@
-documentation_target = "gitlab" #generic: common features for markdown wikis
-                                #gitlab : enables gitlab wiki specific features
-
 scope = [ "tvm", "cdm", "bdr" ]
 skip_model_keys = ["description",
                             "guidelines",
@@ -18,9 +15,11 @@ skip_vocabularies = ["mitigation",
                     "nist",
                     "att&ck"]
 
+model_cover_pages = true #Creates a cover page for the Object sub-folder
+                         #only supported in Gitlab Wiki and Azure DevOps Wiki
+
+
 [gitlab]
-model_cover_pages = true #Creates a cover page for the model sub-folder
-                         #using JSON Tables to facilitate searches
 uuid_permalinks = true   #All markdown files are named using UUIDs to create 
                          #a permanent URL link. YAML frontmatter is used for page titles.
 

--- a/Engines/deployment/sentinel.py
+++ b/Engines/deployment/sentinel.py
@@ -96,7 +96,7 @@ class SentinelDeploy(DeployMDR):
         if techniques:=configuration.alert.techniques:
             rule.techniques = techniques
         if tactics:=configuration.alert.tactics:
-            rule.techniques = tactics
+            rule.tactics = tactics
 
         # Custom Details
         if custom_details:=configuration.alert.custom_details:

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -37,9 +37,12 @@ from Engines.modules.deployment import enabled_systems, CIEnvironment
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 
 DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+log("INFO", "Identified CI Environment", str(DOCUMENTATION_TARGET.name))
 if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
+    log("INFO", "Enabling UUID Permalinking for Gitlab target")
 else:
+    log("INFO", "Disabling UUID Permalinking for Gitlab target")
     UUID_PERMALINKS = False
 
 DEFAULT_RESPONDERS = DataTide.Configurations.Deployment.default_responders

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -32,12 +32,12 @@ from Engines.modules.documentation_components import (
 from Engines.modules.tide import DataTide
 from Engines.modules.logs import log
 from Engines.modules.graphs import relationships_graph
-from Engines.modules.deployment import enabled_systems
+from Engines.modules.deployment import enabled_systems, CIEnvironment
 
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-if DOCUMENTATION_TARGET == "gitlab":
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
 else:
     UUID_PERMALINKS = False
@@ -78,7 +78,7 @@ for sub in SYSTEMS_SUBSCHEMAS.copy():
 
 
 
-if DOCUMENTATION_TARGET == "gitlab":
+if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     MDR_WIKI_PATH = Path(str(MDR_WIKI_PATH).replace(" ", "-"))
     print("🦊 Configured to use Gitlab Flavored Markdown")
 
@@ -92,13 +92,12 @@ def documentation(mdr):
     name = f"{MDR_ICON} {mdr['name']}"
     frontmatter = ""
 
-    if DOCUMENTATION_TARGET == "generic":
-        name = "# " + name
-
-    if DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         if UUID_PERMALINKS:
             frontmatter = f"---\ntitle: {name}\n---"
         name = ""    
+    else:
+        name = "# " + name
 
     uuid_data = mdr["metadata"]["uuid"]
     description = mdr.get("description", "").replace("\n", "\n> ")
@@ -116,7 +115,7 @@ def documentation(mdr):
 
     if not relation_graph:
         relations = "🚫 No related objects indexed."
-        if DOCUMENTATION_TARGET == "gitlab":
+        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
             GitlabMarkdown.negative_diff(relation_graph)
     else:
         relations = relation_graph + "\n\n" + relation_table
@@ -141,7 +140,7 @@ def documentation(mdr):
     playbook_col = get_field_title("playbook", MDR_METASCHEMA)
     if not playbook_data:
         playbook_data = "No playbook was defined for this detection rule"
-        if DOCUMENTATION_TARGET == "gitlab":
+        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
             playbook_data = f"[-{playbook_data}-]"
     else:
         playbook_name = playbook_data.split("/")[-1]
@@ -289,8 +288,8 @@ def documentation(mdr):
             system_name += "[DISABLED]"
             banner = "This system is not enabled in your System Configurations, "\
                 "this documentation is only informational"
-            if DOCUMENTATION_TARGET == "gitlab":
-                banner = f"[- {banner} -]"
+            if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+                banner = GitlabMarkdown.negative_diff(banner)
             table = banner + "\n\n" + table
                 
         fold = FOLD.format(system_name, table)
@@ -361,7 +360,7 @@ def run():
         document = documentation(mdr_data)
 
         # Replace whitespace in file name as it becomes a path in the Gitlab Wiki
-        if DOCUMENTATION_TARGET == "gitlab":
+        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
             doc_path = Path(str(doc_path).replace(" ", "-"))
 
         with open(doc_path, "w+", encoding="utf-8") as output:

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -91,7 +91,10 @@ def documentation(mdr):
     name = f"{MDR_ICON} {mdr['name']}"
     frontmatter = ""
 
-    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+    # For some wikis, the file name is used as the page display name,
+    # in which case it is redundant to also have the name as an H1
+    if DOCUMENTATION_TARGET in [CIEnvironment.CIPlatforms.GitlabCI,
+                                CIEnvironment.CIPlatforms.AzurePipeline]:
         if UUID_PERMALINKS:
             frontmatter = f"---\ntitle: {name}\n---"
         name = ""    

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -77,7 +77,7 @@ for sub in SYSTEMS_SUBSCHEMAS.copy():
 
 
 
-if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+if DOCUMENTATION_TARGET in TARGET_WITH_DASH_PATHS:
     MDR_WIKI_PATH = Path(str(MDR_WIKI_PATH).replace(" ", "-"))
     print("🦊 Configured to use Gitlab Flavored Markdown")
 
@@ -92,9 +92,7 @@ def documentation(mdr):
     frontmatter = ""
 
     if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
-        log("INFO", "Generating for Gitlab", name)
         if UUID_PERMALINKS:
-            log("INFO", "UUID Permalinks enabled")
             frontmatter = f"---\ntitle: {name}\n---"
         name = ""    
     else:

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -37,6 +37,13 @@ from Engines.modules.deployment import enabled_systems, CIEnvironment
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 
 DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+
+# Wiki Environments that require replacing all spaces in file names with
+# dashes
+
+TARGET_WITH_DASH_PATHS = [CIEnvironment.CIPlatforms.AzurePipeline,
+                          CIEnvironment.CIPlatforms.GitlabCI]
+
 log("INFO", "Identified CI Environment", str(DOCUMENTATION_TARGET.name))
 if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
@@ -362,12 +369,11 @@ def run():
             doc_file_name = safe_file_name(doc_file_name)
             
         doc_path = MDR_WIKI_PATH / doc_file_name
-        
 
         document = documentation(mdr_data)
 
         # Replace whitespace in file name as it becomes a path in the Gitlab Wiki
-        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+        if DOCUMENTATION_TARGET in TARGET_WITH_DASH_PATHS:
             doc_path = Path(str(doc_path).replace(" ", "-"))
 
         with open(doc_path, "w+", encoding="utf-8") as output:

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -96,7 +96,9 @@ def documentation(mdr):
     frontmatter = ""
 
     if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+        log("INFO", "Generating for Gitlab", name)
         if UUID_PERMALINKS:
+            log("INFO", "UUID Permalinks enabled")
             frontmatter = f"---\ntitle: {name}\n---"
         name = ""    
     else:
@@ -350,7 +352,9 @@ def run():
             mdr_uuid
             )
 
-        if UUID_PERMALINKS:
+        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI and UUID_PERMALINKS:
+            log("INFO", "Generating docs with UUID as file name")
+            log("INFO", "Target CI is", str(DOCUMENTATION_TARGET))
             doc_file_name = mdr_data.get("metadata").get("uuid")+ ".md"
         else:
             doc_name = mdr_data.get("name").replace("_", " ")

--- a/Engines/documentation/mdr.py
+++ b/Engines/documentation/mdr.py
@@ -33,24 +33,13 @@ from Engines.modules.tide import DataTide
 from Engines.modules.logs import log
 from Engines.modules.graphs import relationships_graph
 from Engines.modules.deployment import enabled_systems, CIEnvironment
+from Engines.modules.documentation import (
+    TARGET_WITH_DASH_PATHS,
+    DOCUMENTATION_TARGET,
+    UUID_PERMALINKS
+)
 
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
-
-DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
-
-# Wiki Environments that require replacing all spaces in file names with
-# dashes
-
-TARGET_WITH_DASH_PATHS = [CIEnvironment.CIPlatforms.AzurePipeline,
-                          CIEnvironment.CIPlatforms.GitlabCI]
-
-log("INFO", "Identified CI Environment", str(DOCUMENTATION_TARGET.name))
-if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
-    UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
-    log("INFO", "Enabling UUID Permalinking for Gitlab target")
-else:
-    log("INFO", "Disabling UUID Permalinking for Gitlab target")
-    UUID_PERMALINKS = False
 
 DEFAULT_RESPONDERS = DataTide.Configurations.Deployment.default_responders
 SYSTEMS_CONFIG = DataTide.Configurations.Systems.Index

--- a/Engines/documentation/metaschemas.py
+++ b/Engines/documentation/metaschemas.py
@@ -14,6 +14,7 @@ sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
 from Engines.modules.documentation import get_icon, name_subschema_doc
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
+from Engines.modules.deployment import CIEnvironment
 
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 
@@ -25,8 +26,7 @@ TEMPLATES_INDEX = DataTide.Templates.Index
 SCHEMA_DOCS_PATH = Path(DataTide.Configurations.Global.Paths.Core.schemas_docs_folder)
 DOC_TITLES = DataTide.Configurations.Documentation.titles
 ICONS = DataTide.Configurations.Documentation.icons
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
 
 # Columns of the dataframe which will constructs the table
 columns = ["Field", "Name", "Description", "Type", "Example"]
@@ -86,7 +86,7 @@ def gen_schema_md(metaschema, template, model_type=None):
                                                    template=template,
                                                    template_name=template_name)
     
-    if DOCUMENTATION_TARGET == "generic":
+    if DOCUMENTATION_TARGET is not CIEnvironment.CIPlatforms.GitlabCI:
         if title:
             documentation = f"# {title} \n\n" + documentation
 
@@ -184,7 +184,7 @@ def run():
             doc = gen_schema_md(meta, template, model)
             output_path = SCHEMA_DOCS_PATH / (icon + " " + DOC_TITLES[model] + ".md")
             
-            if DOCUMENTATION_TARGET == "gitlab":
+            if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
                 output_path = Path(str(output_path).replace(" ", "-"))
             
             with open(output_path, "w+", encoding='utf-8') as output:
@@ -204,14 +204,14 @@ def run():
                 doc = gen_schema_md(subschema, sub_template)
                 output_path = SCHEMA_DOCS_PATH / (subschema_name + ".md")
             
-                if DOCUMENTATION_TARGET == "gitlab":
+                if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
                     output_path = Path(str(output_path).replace(" ", "-"))
 
                 with open(output_path, "w+", encoding='utf-8') as output:
                     output.write(doc)
 
 
-    if DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         doc_format_log = "🦊 Gitlab Flavored Markdown"    
     else:
         doc_format_log = "✒️ Standard markdown"

--- a/Engines/documentation/models.py
+++ b/Engines/documentation/models.py
@@ -205,7 +205,7 @@ def run():
             MODELS_DOCS_PATH
             / MODELS_NAME[model_type]
         )
-        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+        if DOCUMENTATION_TARGET in TARGET_WITH_DASH_PATHS:
             doc_type_path = Path(str(doc_type_path).replace(" ", "-"))
 
         # Remove everything in the doc folder for the model

--- a/Engines/documentation/models.py
+++ b/Engines/documentation/models.py
@@ -3,9 +3,6 @@ import git
 from pathlib import Path
 import sys
 import shutil
-import time
-
-start_time = time.time()
 
 sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
 from Engines.modules.framework import (
@@ -38,14 +35,15 @@ from Engines.modules.graphs import relationships_graph, chaining_graph
 from Engines.modules.tide import DataTide
 from Engines.modules.logs import log
 from Engines.modules.deployment import Proxy
+from Engines.modules.deployment import CIEnvironment
 from Engines.templates.models import MODEL_DOC_TEMPLATE
 
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 MODELS_DOCS_PATH = Path(DataTide.Configurations.Global.Paths.Core.models_docs_folder)
 MODELS_SCOPE = DataTide.Configurations.Documentation.scope
 
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-if DOCUMENTATION_TARGET == "gitlab":
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
 else:
     UUID_PERMALINKS = False
@@ -66,11 +64,11 @@ def documentation(model):
     title = f"{get_icon(model_type)} {model['name']}"
     frontmatter = ""
     
-    if DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         if UUID_PERMALINKS:
             frontmatter = f"---\ntitle: {title}\n---"            
         title = ""
-    elif DOCUMENTATION_TARGET == "generic":
+    else:
         title = "# " + title
         
     model_datafield = DataTide.Configurations.Global.data_fields[model_type]
@@ -84,9 +82,6 @@ def documentation(model):
     expand_graphs = ""
 
     actors_sightings = ""
-
-    if DOCUMENTATION_TARGET == "gitlab":
-        title = ""
 
     references = model.get("references")
     
@@ -132,7 +127,7 @@ def documentation(model):
 
     if not relation_graph and not relation_table:
         relation_graph = "🚫 No related OpenTide objects indexed."
-        if DOCUMENTATION_TARGET == "gitlab":
+        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
             GitlabMarkdown.negative_diff(relation_graph)
 
     if model_type == "bdr":
@@ -172,7 +167,7 @@ def documentation(model):
 
     data_table, tags = model_data_table(model[model_datafield], model_uuid)
 
-    if DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         tags = ""
     else:
         tags = "---\n\n#### 🏷️ Tags\n\n"
@@ -215,7 +210,7 @@ def run():
             MODELS_DOCS_PATH
             / MODELS_NAME[model_type]
         )
-        if DOCUMENTATION_TARGET== "gitlab":
+        if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
             doc_type_path = Path(str(doc_type_path).replace(" ", "-"))
 
         # Remove everything in the doc folder for the model
@@ -246,7 +241,7 @@ def run():
             doc_path = doc_type_path / doc_file_name
 
             # Replace whitespace in file name as it becomes a path in the Gitlab MODELS_DOCS_PATH
-            if DOCUMENTATION_TARGET == "gitlab":
+            if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
                 doc_path = Path(str(doc_path).replace(" ", "-"))
 
             log("ONGOING",
@@ -260,17 +255,7 @@ def run():
                 output.write(document)
                 doc_count += 1
 
-    if DOCUMENTATION_TARGET == "generic":
-        doc_format_log = "✒️ standard markdown"
-    elif DOCUMENTATION_TARGET == "gitlab":
-        doc_format_log = "🦊 Gitlab Flavored Markdown"
-    else:
-        doc_format_log = ""
-
-    time_to_execute = "%.2f" % (time.time() - start_time)
-
-    log("INFO", f"Generated {doc_count} documents in {time_to_execute} seconds")
-    log("SUCCESS", "Successfully built CoreTIDE documentation in format", doc_format_log)
+    log("SUCCESS", "Successfully built CoreTIDE documentation")
 
 
 if __name__ == "__main__":

--- a/Engines/documentation/models.py
+++ b/Engines/documentation/models.py
@@ -18,6 +18,9 @@ from Engines.modules.documentation import (
     GitlabMarkdown,
     sanitize_hover,
     FOLD,
+    DOCUMENTATION_TARGET,
+    UUID_PERMALINKS,
+    TARGET_WITH_DASH_PATHS
 )
 from Engines.modules.documentation_components import (
     criticality_doc,
@@ -34,20 +37,12 @@ from Engines.modules.files import safe_file_name
 from Engines.modules.graphs import relationships_graph, chaining_graph
 from Engines.modules.tide import DataTide
 from Engines.modules.logs import log
-from Engines.modules.deployment import Proxy
-from Engines.modules.deployment import CIEnvironment
+from Engines.modules.deployment import Proxy, CIEnvironment
 from Engines.templates.models import MODEL_DOC_TEMPLATE
 
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 MODELS_DOCS_PATH = Path(DataTide.Configurations.Global.Paths.Core.models_docs_folder)
 MODELS_SCOPE = DataTide.Configurations.Documentation.scope
-
-DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
-if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
-    UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
-else:
-    UUID_PERMALINKS = False
-
 MODELS_INDEX = DataTide.Models.Index
 MODELS_NAME = DataTide.Configurations.Documentation.object_names
 
@@ -241,7 +236,7 @@ def run():
             doc_path = doc_type_path / doc_file_name
 
             # Replace whitespace in file name as it becomes a path in the Gitlab MODELS_DOCS_PATH
-            if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+            if DOCUMENTATION_TARGET in TARGET_WITH_DASH_PATHS:
                 doc_path = Path(str(doc_path).replace(" ", "-"))
 
             log("ONGOING",

--- a/Engines/documentation/vocabularies.py
+++ b/Engines/documentation/vocabularies.py
@@ -2,25 +2,22 @@ import pandas as pd
 import os
 import git
 import shutil
-import time
 import sys
 from pathlib import Path
-
-start_time = time.time()
-
 
 sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
 
 from Engines.modules.documentation import get_icon, make_json_table
 from Engines.modules.tide import DataTide
 from Engines.modules.logs import log
+from Engines.modules.deployment import CIEnvironment
 from Engines.templates.models import VOCABS_DOC_TEMPLATE
 
 ROOT = Path(str(git.Repo(".", search_parent_directories=True).working_dir))
 
 VOCAB_INDEX = DataTide.Vocabularies.Index
 ICONS = DataTide.Configurations.Documentation.icons
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
 VOCAB_DOCS_PATH = Path(DataTide.Configurations.Global.Paths.Core.vocabularies_docs)
 SKIP_VOCABS = DataTide.Configurations.Documentation.skip_vocabularies
 
@@ -105,11 +102,11 @@ def make_vocab_doc(vocab_field, vocabulary):
     df = df.replace("\n", ". ", regex=True)
     table = str()
 
-    if DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         title = ""
         table = make_json_table(df)
         
-    elif DOCUMENTATION_TARGET == "generic":
+    else:
         title = "# " + name
         table = df.to_markdown(index=False)
 
@@ -155,23 +152,12 @@ def run():
                     output_name = icon + " " + name + ".md"
                     output_path = VOCAB_DOCS_PATH / output_name
 
-                    if DOCUMENTATION_TARGET == "gitlab":
+                    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
                         output_path = Path(str(output_path).replace(" ", "-"))
 
                     with open(output_path, "w+", encoding="utf-8") as output:
                         output.write(documentation)
-
-    doc_format_log = str()
-    if DOCUMENTATION_TARGET == "gitlab":
-        doc_format_log = "🦊 Gitlab Flavored Markdown"
-    else:
-        doc_format_log = "✒️ standard markdown"
-
-    time_to_execute = "%.2f" % (time.time() - start_time)
-
-    print("\n⏱️ Generated documentation in {} seconds".format(time_to_execute))
-    print("✅ Successfully built vocabulary documentation in {}".format(doc_format_log))
-
+    log("SUCCESS", "Successfully built vocabulary documentation")
 
 if __name__ == "__main__":
     run()

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -263,8 +263,11 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
     }
     df = df.rename(columns=rename_mapping)
 
-    nav_index = make_json_table(df)
-
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+        nav_index = make_json_table(df)
+    else:
+        nav_index = df.to_csv(index=False)
+        
     return nav_index
 
 

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -293,8 +293,11 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
     }
     df = df.rename(columns=rename_mapping)
 
-    nav_index = make_json_table(df)
-
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+        nav_index = make_json_table(df)
+    else:
+        nav_index = df.to_csv(index=False)
+        
     return nav_index
 
 

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -164,6 +164,8 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                 techniques = techniques_resolver(entry)
                 if techniques:
                     techniques = rich_attack_links(techniques)
+                    if model_type == "mdr":
+                        value = mdr_attack_technique
                     row[value] = techniques
                 else:
                     "❔ No ATT&CK Technique Mapped"

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -296,7 +296,7 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
     if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         nav_index = make_json_table(df)
     else:
-        nav_index = df.to_csv(index=False)
+        nav_index = df.to_markdown(index=False)
 
     return nav_index
 

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -29,14 +29,10 @@ from Engines.modules.documentation import (
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
 from Engines.modules.debug import DebugEnvironment
+from Engines.modules.deployment import CIEnvironment
 
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-COVER_PAGES_ENABLED = DataTide.Configurations.Documentation.gitlab.get("model_cover_pages", False)
-
-# For testing purposes, enabling this script to execute
-if DebugEnvironment.ENABLED:
-    DOCUMENTATION_TARGET = "gitlab"
-    COVER_PAGES_ENABLED = True
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+COVER_PAGES_ENABLED = DataTide.Configurations.Documentation.model_cover_pages
 
 MODELS_INDEX = DataTide.Models.Index
 METASCHEMAS_INDEX = DataTide.TideSchemas.Index
@@ -367,19 +363,18 @@ def run():
         "Assembles tables exposing CoreTIDE data to make the dataset easier to navigate",
     )
 
-    if DOCUMENTATION_TARGET != "gitlab":
+    if DOCUMENTATION_TARGET not in [CIEnvironment.CIPlatforms.GitlabCI,
+                                    CIEnvironment.CIPlatforms.AzurePipeline] :
         log("SKIP",
-            "This is a Gitlab Wiki only feature",
-            f"documentation_target is currently set to : {DOCUMENTATION_TARGET}",
-            "If you are running OpenTIDE in Gitlab, we advise to change this configuration \
-                to 'gitlab' to enjoy all documentation features")
+            "This is a Gitlab Wiki or Azure Pipeline only feature",
+            f"documentation_target is currently set to : {DOCUMENTATION_TARGET}")
         return 
 
     if not COVER_PAGES_ENABLED:
         log("SKIP",
             "Disabled in configuration",
             "Not generating cover pages as set to false or missing key",
-            "You can enable this feature by setting gitlab.model_cover_pages to True in documentation.toml")
+            "You can enable this feature by setting model_cover_pages to True in documentation.toml")
         return
 
     if not os.path.exists(MODELS_DOCS_PATH):

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -24,14 +24,14 @@ from Engines.modules.documentation import (
     get_field_title,
     make_json_table,
     backlink_resolver,
-    rich_attack_links
+    rich_attack_links,
+    DOCUMENTATION_TARGET,
 )
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
 from Engines.modules.debug import DebugEnvironment
 from Engines.modules.deployment import CIEnvironment
 
-DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
 COVER_PAGES_ENABLED = DataTide.Configurations.Documentation.model_cover_pages
 
 MODELS_INDEX = DataTide.Models.Index
@@ -297,7 +297,7 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
         nav_index = make_json_table(df)
     else:
         nav_index = df.to_csv(index=False)
-        
+
     return nav_index
 
 

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -23,6 +23,8 @@ from Engines.modules.documentation import (
     get_icon,
     get_field_title,
     make_json_table,
+    backlink_resolver,
+    rich_attack_links
 )
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
@@ -152,8 +154,21 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
 
         
         for value in NAV_INDEX_FIELDS[model_type]:
-            
-            if value == "implementations":
+
+            if value == "name":
+                object_backlink = str(backlink_resolver(str(model_value_doc(entry, "uuid"))))
+                object_backlink = object_backlink.replace("../", "./")
+                row[value] = object_backlink
+
+            elif value == "att&ck":
+                techniques = techniques_resolver(entry)
+                if techniques:
+                    techniques = rich_attack_links(techniques)
+                    row[value] = techniques
+                else:
+                    "❔ No ATT&CK Technique Mapped"
+
+            elif value == "implementations":
                 relations = relations_list(entry, mode="count", direction="downstream")
                 implementations = []
 
@@ -183,9 +198,6 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                 actors_list = ", ".join(actors_list)
                 row[value] = actors_list
 
-            elif model_type == "cdm" and value == "att&ck":
-                techniques = ", ".join(techniques_resolver(entry))
-                row[value] = techniques
 
             elif model_type == "mdr":
 
@@ -208,11 +220,6 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                     )
                     row[mdr_statuses] = statuses
 
-                elif value == "name":
-                    mdr_name = model_value_doc(entry, "name")
-                    row[value] = mdr_name
-
-                # List
                 elif value == "att&ck":
                     model_value = (
                         techniques_resolver(str(model_value_doc(entry, "uuid")))
@@ -222,11 +229,20 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                         model_value = ", ".join(model_value)
                     row[mdr_attack_technique] = model_value
 
+                elif value == "detection_model":
+                    model_value = model_value_doc(entry, "detection_model")
+                    if model_value:
+                        object_backlink = str(backlink_resolver(str(model_value)))
+                        object_backlink = object_backlink.replace("../", "./")
+                        row[value] = object_backlink
+                    else:
+                        row[value] = "❔ No Object Mapped"
+
                 else:
                     model_value = model_value_doc(
                         entry, value, with_icon=True, max_chars=CHARS_CLIP
                     )
-                    row[value] = model_value
+                    row[value] = str(model_value).replace("\n", " ").replace('"', "")
 
             else:
                 model_value = model_value_doc(
@@ -255,7 +271,7 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                     else:
                         model_value = ""
 
-                row[value] = model_value
+                row[value] = str(model_value).replace("\n", " ").replace('"', "")
 
         index.append(row)
 

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -27,14 +27,10 @@ from Engines.modules.documentation import (
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
 from Engines.modules.debug import DebugEnvironment
+from Engines.modules.deployment import CIEnvironment
 
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-COVER_PAGES_ENABLED = DataTide.Configurations.Documentation.gitlab.get("model_cover_pages", False)
-
-# For testing purposes, enabling this script to execute
-if DebugEnvironment.ENABLED:
-    DOCUMENTATION_TARGET = "gitlab"
-    COVER_PAGES_ENABLED = True
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+COVER_PAGES_ENABLED = DataTide.Configurations.Documentation.model_cover_pages
 
 MODELS_INDEX = DataTide.Models.Index
 METASCHEMAS_INDEX = DataTide.TideSchemas.Index
@@ -337,19 +333,18 @@ def run():
         "Assembles tables exposing CoreTIDE data to make the dataset easier to navigate",
     )
 
-    if DOCUMENTATION_TARGET != "gitlab":
+    if DOCUMENTATION_TARGET not in [CIEnvironment.CIPlatforms.GitlabCI,
+                                    CIEnvironment.CIPlatforms.AzurePipeline] :
         log("SKIP",
-            "This is a Gitlab Wiki only feature",
-            f"documentation_target is currently set to : {DOCUMENTATION_TARGET}",
-            "If you are running OpenTIDE in Gitlab, we advise to change this configuration \
-                to 'gitlab' to enjoy all documentation features")
+            "This is a Gitlab Wiki or Azure Pipeline only feature",
+            f"documentation_target is currently set to : {DOCUMENTATION_TARGET}")
         return 
 
     if not COVER_PAGES_ENABLED:
         log("SKIP",
             "Disabled in configuration",
             "Not generating cover pages as set to false or missing key",
-            "You can enable this feature by setting gitlab.model_cover_pages to True in documentation.toml")
+            "You can enable this feature by setting model_cover_pages to True in documentation.toml")
         return
 
     if not os.path.exists(MODELS_DOCS_PATH):

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -198,6 +198,18 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                 actors_list = ", ".join(actors_list)
                 row[value] = actors_list
 
+            elif model_type == "cdm" and value == "vectors":
+                vectors = model_value_doc(entry, "vectors")
+                if vectors:
+                    vectors = [vectors] if type(vectors) is str else vectors
+                    vectors_links = []
+                    for vector in vectors:
+                        object_backlink = str(backlink_resolver(str(vector)))
+                        object_backlink = object_backlink.replace("../", "./")
+                        vectors_links.append(object_backlink)
+                    row[value] = ", ".join(vectors_links)
+                else:
+                    row[value] = "❔ No Object Mapped"
 
             elif model_type == "mdr":
 

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -399,7 +399,7 @@ def diff_calculation(plan: DeploymentStrategy) -> list:
     diff = source_commit.diff(latest_commit)
 
     log(
-        "DEBUG",
+        "INFO",
         "Preliminary diff calculation completed, returned with",
         ", ".join([f.b_path for f in diff]),
     )

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -49,6 +49,7 @@ class CIEnvironment:
         AzurePipeline = auto()
         GitlabCI = auto()
         GitHubActions = auto()
+        LocalDebug = auto()
 
     def _check_ci_environment(self) -> CIPlatforms:
         if os.getenv("TF_BUILD"):
@@ -60,12 +61,15 @@ class CIEnvironment:
         elif os.getenv("CI"):
             log("SUCCESS", "Discovered CI Environment to be Gitlab CI")
             return self.CIPlatforms.GitlabCI
+        elif HelperTide.is_debug():
+            log("SUCCESS", "Discover CI Environment to be Local")
+            return self.CIPlatforms.LocalDebug
         else:
             log(
                 "FATAL",
                 "CI Target environment variable is not implemented",
                 "Ensure that you have configured a variable OpenTide.TargetCi as part of your pipeline",
-                "Current supported values: GitlabCI, AzurePipelines",
+                "Current supported values: GitlabCI, AzurePipelines, GitlabActions, LocalDebug",
             )
             raise Exception
 
@@ -532,7 +536,6 @@ class ExternalIdHelper:
                 updated_content.append(line)
 
         with open(file_path, "w", encoding="utf-8") as mdr_file:
-            print("SHIT")
             print(updated_content)
             mdr_file.writelines(updated_content)
             log(
@@ -546,29 +549,29 @@ class TideDeployment:
     def __init__(self, deployment, system: DetectionSystems, strategy):
         match system:
             case DetectionSystems.SPLUNK:
-                self.rule_deployment: Sequence[TenantDeployment.Splunk] = (
+                self.rule_deployment: Sequence[TenantDeployment.Splunk] = ( # type:ignore
                     self.deployment_resolver(deployment, system, strategy)
-                )  # type:ignore
+                )  
             case DetectionSystems.SENTINEL:
-                self.rule_deployment: Sequence[TenantDeployment.Sentinel] = (
-                    self.deployment_resolver(deployment, system, strategy)
-                )  # type:ignore
+                self.rule_deployment: Sequence[TenantDeployment.Sentinel] = ( # type:ignore
+                    self.deployment_resolver(deployment, system, strategy) 
+                )
             case DetectionSystems.CARBON_BLACK_CLOUD:
-                self.rule_deployment: Sequence[TenantDeployment.CarbonBlackCloud] = (
+                self.rule_deployment: Sequence[TenantDeployment.CarbonBlackCloud] = ( # type:ignore
                     self.deployment_resolver(deployment, system, strategy)
-                )  # type:ignore
+                )
             case DetectionSystems.DEFENDER_FOR_ENDPOINT:
-                self.rule_deployment: Sequence[TenantDeployment.DefenderForEndpoint] = (
+                self.rule_deployment: Sequence[TenantDeployment.DefenderForEndpoint] = ( # type:ignore
                     self.deployment_resolver(deployment, system, strategy)
-                )  # type:ignore
+                )
             case DetectionSystems.SENTINEL_ONE:
-                self.rule_deployment: Sequence[TenantDeployment.SentinelOne] = (
+                self.rule_deployment: Sequence[TenantDeployment.SentinelOne] = ( # type:ignore
                     self.deployment_resolver(deployment, system, strategy)
-                )  # type:ignore
+                ) 
             case DetectionSystems.CROWDSTRIKE:
                 self.rule_deployment: Sequence[TenantDeployment.Crowdstrike] = (
-                    self.deployment_resolver(deployment, system, strategy)
-                )  # type:ignore
+                    self.deployment_resolver(deployment, system, strategy) # type:ignore
+                )
             case _:
                 raise NotImplementedError(
                     f"System {system} is not implemented by TideDeployment"
@@ -820,8 +823,8 @@ class TideDeployment:
                         str(mod.description or ""),
                     )
                     flatten_modifications = pd.json_normalize(
-                        mod.modifications
-                    ).to_dict(orient="records")[0]  # type: ignore
+                        mod.modifications # type: ignore
+                    ).to_dict(orient="records")[0] 
                     for modification in flatten_modifications:
                         new_value = flatten_modifications[modification]
                         new_value = None if new_value in [
@@ -831,8 +834,8 @@ class TideDeployment:
                                 pass
                             elif "::" in new_value:
                                 raw_mdr_config_flatten = pd.json_normalize(
-                                    raw_mdr_config
-                                ).to_dict(orient="records")[0]  # type: ignore
+                                    raw_mdr_config # type: ignore
+                                ).to_dict(orient="records")[0]  
                                 operator = new_value.split("::")[0]
                                 value = new_value.split("::")[1]
                                 log(
@@ -868,8 +871,8 @@ class TideDeployment:
                         )
                         if updated_config:
                             raw_mdr_config = self._deep_update(
-                                raw_mdr_config.copy(), updated_config
-                            )  # type: ignore
+                                raw_mdr_config.copy(), updated_config # type: ignore
+                            )  
 
         raw_data["configurations"].update({system_identifier: raw_mdr_config})
         log("INFO", "New recompiled modified deployment", str(raw_data))

--- a/Engines/modules/documentation.py
+++ b/Engines/modules/documentation.py
@@ -16,12 +16,22 @@ from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
 from Engines.modules.deployment import CIEnvironment
 
+# Wiki Environments that require replacing all spaces in file names with
+# dashes
+TARGET_WITH_DASH_PATHS = [CIEnvironment.CIPlatforms.AzurePipeline,
+                            CIEnvironment.CIPlatforms.GitlabCI]
+
+
 VOCAB_INDEX = DataTide.Vocabularies.Index
 DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+log("INFO", "Identified CI Environment", str(DOCUMENTATION_TARGET.name))
 if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
+    log("INFO", "Enabling UUID Permalinking for Gitlab target")
 else:
+    log("INFO", "Disabling UUID Permalinking for Gitlab target")
     UUID_PERMALINKS = False
+
 ICONS = DataTide.Configurations.Documentation.icons
 DOCUMENTATION_CONFIG = DataTide.Configurations.Documentation
 CONFIG_INDEX = DataTide.Configurations.Index
@@ -273,7 +283,7 @@ def backlink_resolver(model_uuid:str,
         backlink_name = model_name
         file_link = f"{doc_path}{icon} {model_name}"
 
-    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
+    if DOCUMENTATION_TARGET in TARGET_WITH_DASH_PATHS:
         if UUID_PERMALINKS:
             file_link = doc_path + model_data.get("metadata",{}).get("uuid")
         file_link = file_link.replace(" ", "-").replace("_", "-")

--- a/Engines/modules/documentation.py
+++ b/Engines/modules/documentation.py
@@ -54,15 +54,8 @@ def sanitize_hover(hover: str) -> str:
     Removes forbidden characters from infobubbles/popovers on
     markdown formatted links
     """
-    hover = hover.replace("\n", " ")
-    hover = hover.replace("'", "")
-    hover = hover.replace('"', "")
-    hover = hover.replace("]", "")
-    hover = hover.replace("[", "")
-    hover = hover.replace("(", "")
-    hover = hover.replace(")", "")
-    hover = hover.replace("|", "")
-    return hover
+    ALLOWED_CHARACTERS = ["&", "#" ," ", ";", ",", "-", "_"]
+    return ''.join(ch for ch in hover if (ch.isalnum() or (ch in ALLOWED_CHARACTERS)))
 
 
 def object_name(key):
@@ -121,6 +114,8 @@ def make_json_table(dataframe: pd.DataFrame) -> str:
         "fields": sortable_columns,
         "items": optimized_items,
         "filter": "true",
+        "markdown": "true",
+        "sortable": "true"
     }
 
     # Dumps as an escaped string
@@ -187,7 +182,7 @@ def make_attack_link(
 
     if hover:
         technique_description = details["description"]
-        technique_link += f' "{sanitize_hover(technique_description)}"'
+        technique_link += f" '{sanitize_hover(technique_description)[:150]}'"
 
     link = f"[{link_title}]({technique_link})"
 
@@ -267,7 +262,7 @@ def backlink_resolver(model_uuid:str,
         backlink_name = model_name.replace("_", " ")
         hover = "&#013;&#010;".join(
             mdr_statuses(model_uuid)
-        )  # Magic entity codes to break in tooltips
+        ) 
         mdr_description = model_value(model_uuid, "description") or ""
         mdr_description = mdr_description
         hover += f"&#013;&#010;&#013;&#010;{mdr_description}"
@@ -288,8 +283,8 @@ def backlink_resolver(model_uuid:str,
 
     hover = sanitize_hover(str(hover))
     if len(hover) > hover_length:
-        hover = hover[hover_length:] + "..."  
-    backlink = f'[{backlink_name}]({file_link} "{hover}")'
+        hover = hover[:hover_length] + "..."  
+    backlink = f"[{backlink_name}]({file_link} '{hover}')"
     
     if raw_link:
         if raw_hover:

--- a/Engines/modules/documentation.py
+++ b/Engines/modules/documentation.py
@@ -14,10 +14,11 @@ from Engines.modules.framework import (
 )
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
+from Engines.modules.deployment import CIEnvironment
 
 VOCAB_INDEX = DataTide.Vocabularies.Index
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-if DOCUMENTATION_TARGET == "gitlab":
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
 else:
     UUID_PERMALINKS = False
@@ -272,14 +273,14 @@ def backlink_resolver(model_uuid:str,
         backlink_name = model_name
         file_link = f"{doc_path}{icon} {model_name}"
 
-    if DOCUMENTATION_TARGET == "generic":
-        file_link = file_link.replace(" ", "%20")
-        file_link += ".md"
-
-    elif DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         if UUID_PERMALINKS:
             file_link = doc_path + model_data.get("metadata",{}).get("uuid")
         file_link = file_link.replace(" ", "-").replace("_", "-")
+    else:
+        file_link = file_link.replace(" ", "%20")
+        file_link += ".md"
+
 
     hover = sanitize_hover(str(hover))
     if len(hover) > hover_length:

--- a/Engines/modules/documentation.py
+++ b/Engines/modules/documentation.py
@@ -14,10 +14,11 @@ from Engines.modules.framework import (
 )
 from Engines.modules.logs import log
 from Engines.modules.tide import DataTide
+from Engines.modules.deployment import CIEnvironment
 
 VOCAB_INDEX = DataTide.Vocabularies.Index
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
-if DOCUMENTATION_TARGET == "gitlab":
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
+if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
     UUID_PERMALINKS = DataTide.Configurations.Documentation.gitlab.get("uuid_permalinks", False)
 else:
     UUID_PERMALINKS = False
@@ -277,14 +278,14 @@ def backlink_resolver(model_uuid:str,
         backlink_name = model_name
         file_link = f"{doc_path}{icon} {model_name}"
 
-    if DOCUMENTATION_TARGET == "generic":
-        file_link = file_link.replace(" ", "%20")
-        file_link += ".md"
-
-    elif DOCUMENTATION_TARGET == "gitlab":
+    if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
         if UUID_PERMALINKS:
             file_link = doc_path + model_data.get("metadata",{}).get("uuid")
         file_link = file_link.replace(" ", "-").replace("_", "-")
+    else:
+        file_link = file_link.replace(" ", "%20")
+        file_link += ".md"
+
 
     hover = sanitize_hover(str(hover))
     if len(hover) > hover_length:

--- a/Engines/modules/documentation_components.py
+++ b/Engines/modules/documentation_components.py
@@ -9,11 +9,12 @@ from typing import Tuple, Literal
 sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
 
 from Engines.modules.tide import DataTide, IndexTide
+from Engines.modules.deployment import CIEnvironment
 
 CONFIG = DataTide.Configurations
 INDEX = DataTide.Index
 SKIP_KEYS = DataTide.Configurations.Documentation.skip_model_keys
-DOCUMENTATION_TARGET = DataTide.Configurations.Documentation.documentation_target
+DOCUMENTATION_TARGET = CIEnvironment()._check_ci_environment()
 DEFINITIONS_INDEX = DataTide.TideSchemas.definitions
 
 from Engines.modules.framework import (
@@ -331,7 +332,7 @@ def cve_doc(cve_list: list[str]) -> str:
                 cve_doc_list.append(f"[💔 {broken_vuln}]({CVE_DB_LINK}{broken_vuln})")
 
             cve_error_banner = "⚠️ ERROR : Could not successfully retrieve CVE Details, double check the broken links below to confirm the CVE ID exists."
-            if DOCUMENTATION_TARGET == "gitlab":
+            if DOCUMENTATION_TARGET is CIEnvironment.CIPlatforms.GitlabCI:
                 cve_error_banner = GitlabMarkdown.negative_diff(cve_error_banner)
             cve_data = "- " + "\n- ".join(cve_doc_list)
             cve_data = cve_error_banner + "\n\n" + cve_data

--- a/Engines/modules/tide.py
+++ b/Engines/modules/tide.py
@@ -860,25 +860,20 @@ class DataTide:
 
 
             Index = dict(IndexTide.load()["configurations"]["documentation"])
-            documentation_target = str(Index.get("documentation_target"))
             scope = list(Index["scope"])
             skip_model_keys = list(Index["skip_model_keys"])
             skip_vocabularies = list(Index["skip_model_keys"])
             gitlab = dict(Index.get("gitlab", {}))
+            model_cover_pages:bool = Index.get("model_cover_pages", False)
             cve = dict(Index["cve"])
             wiki = dict(Index.get("wiki",{}))
             object_names = dict(Index["object_names"])
             titles = dict(Index["titles"])
             icons = dict(Index["icons"])
-            models_docs_folder: Path = Path(
+            models_docs_folder:Path = Path(
                 IndexTide.load()["configurations"]["global"]["paths"]["core"][
                     "models_docs_folder"
                 ]
-            )
-            models_docs_folder = (
-                Path(str(models_docs_folder).replace(" ", "-"))
-                if documentation_target == "gitlab"
-                else models_docs_folder
             )
 
         @dataclass(frozen=True)

--- a/Engines/requirements.txt
+++ b/Engines/requirements.txt
@@ -9,6 +9,6 @@ GitPython
 splunk-sdk
 carbon-black-cloud-sdk
 toml
-azure-mgmt-securityinsight
+azure-mgmt-securityinsight==2.0.0b2
 azure-identity
 azure-monitor-query

--- a/Framework/Vocabulary/ATT&CK Data Sources.yaml
+++ b/Framework/Vocabulary/ATT&CK Data Sources.yaml
@@ -5,7 +5,7 @@ description: Data sources represent the various subjects/topics of information t
   identify specific properties/values of a data source relevant to detecting a given
   ATT&CK technique or sub-technique.
 reference: https://attack.mitre.org/datasources/
-icon: ðŸ“Š
+icon: 🗡️
 keys:
   - id: DS0026
     name: Active Directory

--- a/Pipelines/Azure/jobs/documentation.staging.yml
+++ b/Pipelines/Azure/jobs/documentation.staging.yml
@@ -39,10 +39,7 @@ steps:
     displayName: Move Back Wiki Repo to resources
   - script: |
       cd $(OpenTide.Wiki.RepoName)
-      ls -lah
-      cd Models
-      ls -lah
-      cd ..
+      ls -lR
       [[ $(git status --porcelain) ]] || { echo "No changes, exiting"; exit 0; }
       echo "Updated files, commiting"
       git rebase origin/$(OpenTide.Wiki.BranchName)

--- a/Pipelines/Azure/jobs/documentation.staging.yml
+++ b/Pipelines/Azure/jobs/documentation.staging.yml
@@ -39,6 +39,7 @@ steps:
     displayName: Move Back Wiki Repo to resources
   - script: |
       cd $(OpenTide.Wiki.RepoName)
+      ls -lah
       [[ $(git status --porcelain) ]] || { echo "No changes, exiting"; exit 0; }
       echo "Updated files, commiting"
       git rebase origin/$(OpenTide.Wiki.BranchName)

--- a/Pipelines/Azure/jobs/documentation.staging.yml
+++ b/Pipelines/Azure/jobs/documentation.staging.yml
@@ -40,6 +40,9 @@ steps:
   - script: |
       cd $(OpenTide.Wiki.RepoName)
       ls -lah
+      cd Models
+      ls -lah
+      cd ..
       [[ $(git status --porcelain) ]] || { echo "No changes, exiting"; exit 0; }
       echo "Updated files, commiting"
       git rebase origin/$(OpenTide.Wiki.BranchName)

--- a/Pipelines/Azure/jobs/documentation.yml
+++ b/Pipelines/Azure/jobs/documentation.yml
@@ -36,6 +36,7 @@ steps:
     displayName: Move Back Wiki Repo to resources
   - script: |
       cd $(OpenTide.Wiki.RepoName)
+      ls -lah
       [[ $(git status --porcelain) ]] || { echo "No changes to the Wiki, exiting"; exit 0; }
       echo "Updated files, commiting"
       git rebase origin/$(OpenTide.Wiki.BranchName)

--- a/Pipelines/Azure/jobs/documentation.yml
+++ b/Pipelines/Azure/jobs/documentation.yml
@@ -36,10 +36,7 @@ steps:
     displayName: Move Back Wiki Repo to resources
   - script: |
       cd $(OpenTide.Wiki.RepoName)
-      ls -lah
-      cd Models
-      ls -lah
-      cd ..
+      ls -lR
       [[ $(git status --porcelain) ]] || { echo "No changes to the Wiki, exiting"; exit 0; }
       echo "Updated files, commiting"
       git rebase origin/$(OpenTide.Wiki.BranchName)

--- a/Pipelines/Azure/jobs/documentation.yml
+++ b/Pipelines/Azure/jobs/documentation.yml
@@ -37,6 +37,9 @@ steps:
   - script: |
       cd $(OpenTide.Wiki.RepoName)
       ls -lah
+      cd Models
+      ls -lah
+      cd ..
       [[ $(git status --porcelain) ]] || { echo "No changes to the Wiki, exiting"; exit 0; }
       echo "Updated files, commiting"
       git rebase origin/$(OpenTide.Wiki.BranchName)

--- a/Pipelines/GitHub/deployment/action.yml
+++ b/Pipelines/GitHub/deployment/action.yml
@@ -22,6 +22,7 @@ runs:
     - name: MDR Promotion
       id: mdr_promotion
       shell: bash
+      if: ${{ inputs.deployment_plan }} == "PRODUCTION"
       env:
         CORETIDE_PATH: ${{ inputs.coretide_path }}
       run: |

--- a/Pipelines/Gitlab/modules/deployment.yml
+++ b/Pipelines/Gitlab/modules/deployment.yml
@@ -1,6 +1,8 @@
 🚧 Staging Deployment:
   stage: 🚀 Deployment
-  environment: MDR Staging
+  environment:
+    name: MDR Staging
+    deployment_tier: staging
   script:
     - export DEPLOYMENT_PLAN=STAGING
     - cd $TIDE_CORE_REPO/Orchestration/
@@ -24,7 +26,9 @@
 
 ☄️ Production Deployment:
   stage: 🚀 Deployment
-  environment: MDR Production
+  environment:
+    name: MDR Production
+    deployment_tier: production
   script:
     - git rebase origin/$CI_DEFAULT_BRANCH 
     - export DEPLOYMENT_PLAN=PRODUCTION

--- a/Pipelines/Gitlab/modules/documentation.yml
+++ b/Pipelines/Gitlab/modules/documentation.yml
@@ -5,7 +5,7 @@
     # > Paste the output to the Wiki 
     - git rebase origin/$CI_DEFAULT_BRANCH #Allows to pull latest mutation if there are
     - cd $TIDE_CORE_REPO
-    - git clone $TIDE_WIKI_ACCESS
+    - git clone $TIDE_WIKI_ACCESS --depth 1 # Shallow clone for performance reasons, no need to perform a deep clone
     - pwd 
 
     # Generate index. Stores a copy in wiki for Staging documentation
@@ -47,7 +47,7 @@
   stage: 📖 Documentation
   script:
     - cd $TIDE_CORE_REPO
-    - git clone $TIDE_WIKI_ACCESS
+    - git clone $TIDE_WIKI_ACCESS --depth 1 # Shallow clone for performance reasons, no need to perform a deep clone
     - pwd 
 
     # Extract the staging index to Core Root for reconciliation


### PR DESCRIPTION
### Feature

This PR refactors quite deeply how Wiki are handled. For now, we will assume that when Wiki is enabled, we target the wiki solution of the CI environment. For Example, if we run in a Gitlab CI Pipeline, then we target the Wiki of the Gitlab project. Same for AzurePipelines, and in the future, Github. 

We may want to refactor this further in the future if we want to support other targets, like external documentation repositories, or things like Confluence. At the moment, this allows more robust handling of different Wiki behaviours and workarounds (like reference paths using spaces or dashes, specific feature support like JSON Tables in Gitlab etc.) directly within the handful of documentation module that would require this. 

The current CI environment identification is handled with the same code infrastructure as is used for deployment and diff calculation purposes.