### PR TITLE
feat: extend KQL exclusion syntax with `let` bindings and generalise to Sentinel

### DIFF
--- a/Engines/deployment/defender_for_endpoint.py
+++ b/Engines/deployment/defender_for_endpoint.py
@@ -12,7 +12,8 @@ from Engines.modules.plugins import DeployMDR
 from Engines.modules.models import (TideModels,
                                     DeploymentStrategy,
                                     StatusStrategy) 
-from Engines.modules.deployment import TideDeployment, check_status, compile_kql_query
+from Engines.modules.deployment import TideDeployment, check_status
+from Engines.modules.systems.kql import compile_kql_query
 from Engines.modules.logs import log
 
 from Engines.modules.systems.defender_for_endpoint import (DetectionRule,

--- a/Engines/deployment/defender_for_endpoint.py
+++ b/Engines/deployment/defender_for_endpoint.py
@@ -12,7 +12,7 @@ from Engines.modules.plugins import DeployMDR
 from Engines.modules.models import (TideModels,
                                     DeploymentStrategy,
                                     StatusStrategy) 
-from Engines.modules.deployment import TideDeployment, check_status
+from Engines.modules.deployment import TideDeployment, check_status, compile_kql_query
 from Engines.modules.logs import log
 
 from Engines.modules.systems.defender_for_endpoint import (DetectionRule,
@@ -143,38 +143,10 @@ class DefenderForEndpointDeploy(DeployMDR):
         
         # Check if the rule is enabled or disabled
         is_enabled = False if check_status(mdr_config.status) is StatusStrategy.DISABLEMENT else True
-        
-
 
         # Handle Query and Exclusions
-        let_statements = []
-        exclusions_queries = []
-
-        if exclusions:=mdr_config.exclusions:
-            for exclusion in exclusions:
-                # Applies exclusion if scoped tenant is matching with ongoing deployment
-                # or if no tenant is specified
-                if (exclusion.tenant == tenant) or (not exclusion.tenant):
-                    log("INFO", "Applying exclusion", exclusion.query)
-                    exclusions_queries.append(exclusion.query)
-
-                    # Handles adding additional let statements
-                    if exclusion.let:
-                        for variable, value in exclusion.let.items():
-                            statement = f"let {variable} = {value};"
-                            log("INFO", "Applying let statement", statement)
-                            let_statements.append(statement)
-                            
-        
-        let_block = "\n".join(let_statements)
-        exclusions_block = "\n".join(exclusions_queries)
-        query = mdr_config.query
-        if let_statements:
-            query = let_block + "\n" + query
-        if exclusions_queries:
-            query = query + "\n" + exclusions_block
-        log("INFO", "Final compiled query")
-        print(query)
+        query = compile_kql_query(mdr_config.query, mdr_config.exclusions, tenant)
+        log("INFO", "Final compiled query", query)
 
         # Compile Detection Rule
         rule = DetectionRule(displayName=data.name,

--- a/Engines/deployment/defender_for_endpoint.py
+++ b/Engines/deployment/defender_for_endpoint.py
@@ -144,16 +144,35 @@ class DefenderForEndpointDeploy(DeployMDR):
         # Check if the rule is enabled or disabled
         is_enabled = False if check_status(mdr_config.status) is StatusStrategy.DISABLEMENT else True
         
+
+
         # Handle Query and Exclusions
-        query = mdr_config.query
+        let_statements = []
+        exclusions_queries = []
+
         if exclusions:=mdr_config.exclusions:
             for exclusion in exclusions:
                 # Applies exclusion if scoped tenant is matching with ongoing deployment
                 # or if no tenant is specified
                 if (exclusion.tenant == tenant) or (not exclusion.tenant):
                     log("INFO", "Applying exclusion", exclusion.query)
-                    query += exclusion.query
+                    exclusions_queries.append(exclusion.query)
+
+                    # Handles adding additional let statements
+                    if exclusion.let:
+                        for variable, value in exclusion.let.items():
+                            statement = f"let {variable} = {value};"
+                            log("INFO", "Applying let statement", statement)
+                            let_statements.append(statement)
+                            
         
+        let_block = "\n".join(let_statements)
+        exclusions_block = "\n".join(exclusions_queries)
+        query = mdr_config.query
+        if let_statements:
+            query = let_block + "\n" + query
+        if exclusions_queries:
+            query = query + "\n" + exclusions_block
         log("INFO", "Final compiled query")
         print(query)
 

--- a/Engines/deployment/sentinel.py
+++ b/Engines/deployment/sentinel.py
@@ -29,7 +29,8 @@ class SentinelDeploy(DeployMDR):
 
     def compile_deployment(self,
                            service: SecurityInsights,
-                           data:TideModels.MDR):
+                           data:TideModels.MDR,
+                           tenant:str):
 
         rule = service.alert_rules.models.ScheduledAlertRule()
         
@@ -38,7 +39,40 @@ class SentinelDeploy(DeployMDR):
             raise Exception
         status = configuration.status
         rule.enabled = True
-        rule.query = configuration.query
+
+        # Handle Query and Exclusions
+        let_statements = []
+        exclusions_queries = []
+
+        if exclusions:=configuration.exclusions:
+            for exclusion in exclusions:
+                # Applies exclusion if scoped tenant is matching with ongoing deployment
+                # or if no tenant is specified
+                if (exclusion.tenant == tenant) or (not exclusion.tenant):
+                    log("INFO", "Applying exclusion", exclusion.query)
+                    exclusions_queries.append(exclusion.query)
+
+                    # Handles adding additional let statements
+                    if exclusion.let:
+                        for variable, value in exclusion.let.items():
+                            statement = f"let {variable} = {value};"
+                            log("INFO", "Applying let statement", statement)
+                            let_statements.append(statement)
+                            
+        
+        let_block = "\n".join(let_statements)
+        exclusions_block = "\n".join(exclusions_queries)
+        query = configuration.query
+        
+        if let_statements:
+            query = let_block + "\n" + query
+        if exclusions_queries:
+            query = query + "\n" + exclusions_block
+        
+        log("INFO", "Final compiled query")
+        print(query)
+        
+        rule.query = query
 
         if check_status(status) is StatusStrategy.DISABLEMENT:
             rule.enabled = False
@@ -248,7 +282,8 @@ class SentinelDeploy(DeployMDR):
 
         log("ONGOING", "Compiling Scheduled Alert Object")
         alert_rule = self.compile_deployment(data=data,
-                                             service=service)
+                                             service=service,
+                                             tenant=tenant_config.name)
 
         log("INFO", "Deploying rule to Sentinel")
         service.alert_rules.create_or_update(

--- a/Engines/deployment/sentinel.py
+++ b/Engines/deployment/sentinel.py
@@ -19,7 +19,8 @@ from Engines.modules.models import (TideModels,
                                     TideConfigs,TenantDeployment,
                                     DeploymentStrategy,
                                     StatusStrategy) 
-from Engines.modules.deployment import TideDeployment, check_status, compile_kql_query
+from Engines.modules.deployment import TideDeployment, check_status
+from Engines.modules.systems.kql import compile_kql_query
 from Engines.modules.errors import TideErrors
 
 from azure.mgmt.securityinsight import SecurityInsights

--- a/Engines/deployment/sentinel.py
+++ b/Engines/deployment/sentinel.py
@@ -19,7 +19,7 @@ from Engines.modules.models import (TideModels,
                                     TideConfigs,TenantDeployment,
                                     DeploymentStrategy,
                                     StatusStrategy) 
-from Engines.modules.deployment import TideDeployment, check_status
+from Engines.modules.deployment import TideDeployment, check_status, compile_kql_query
 from Engines.modules.errors import TideErrors
 
 from azure.mgmt.securityinsight import SecurityInsights
@@ -41,42 +41,12 @@ class SentinelDeploy(DeployMDR):
         rule.enabled = True
 
         # Handle Query and Exclusions
-        let_statements = []
-        exclusions_queries = []
-
-        if exclusions:=configuration.exclusions:
-            for exclusion in exclusions:
-                # Applies exclusion if scoped tenant is matching with ongoing deployment
-                # or if no tenant is specified
-                if (exclusion.tenant == tenant) or (not exclusion.tenant):
-                    log("INFO", "Applying exclusion", exclusion.query)
-                    exclusions_queries.append(exclusion.query)
-
-                    # Handles adding additional let statements
-                    if exclusion.let:
-                        for variable, value in exclusion.let.items():
-                            statement = f"let {variable} = {value};"
-                            log("INFO", "Applying let statement", statement)
-                            let_statements.append(statement)
-                            
-        
-        let_block = "\n".join(let_statements)
-        exclusions_block = "\n".join(exclusions_queries)
-        query = configuration.query
-        
-        if let_statements:
-            query = let_block + "\n" + query
-        if exclusions_queries:
-            query = query + "\n" + exclusions_block
-        
-        log("INFO", "Final compiled query")
-        print(query)
-        
+        query = compile_kql_query(configuration.query, configuration.exclusions, tenant)
+        log("INFO", "Final compiled query", query)
         rule.query = query
 
         if check_status(status) is StatusStrategy.DISABLEMENT:
             rule.enabled = False
-
 
         # Handle Template Metadata
         if configuration.template:

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -20,7 +20,7 @@ import os
 import git
 import yaml
 import re
-from typing import MutableMapping, Optional, Sequence
+from typing import MutableMapping, Sequence
 from enum import Enum, auto
 from pathlib import Path
 from dataclasses import asdict, dataclass
@@ -141,77 +141,6 @@ def check_status(status_name:str)->StatusStrategy:
         f"Requested status : {status_name}",
         f"Available statuses in deployment.toml : {statuses_definitions}")
     raise Exception
-
-
-def compile_kql_query(
-    base_query: str,
-    exclusions: Optional[Sequence],
-    tenant: str,
-) -> str:
-    """Compile a KQL query by prepending let statements and appending exclusion filters.
-
-    Iterates through the provided exclusions and, for each one that matches the
-    given tenant (or has no tenant specified), collects its ``let`` variable
-    assignments and its filter fragment.  Let statements are prepended to the
-    base query in the order they appear; exclusion filter fragments are appended
-    in the same order.
-
-    If the same variable name is declared across multiple exclusions, the last
-    definition takes precedence (last-write-wins) to prevent duplicate ``let``
-    declarations which would cause a KQL compile error.
-
-    Args:
-        base_query: The base KQL query string to build upon.
-        exclusions: A sequence of exclusion objects exposing ``tenant``,
-            ``let``, and ``query`` attributes, or ``None`` when there are no
-            exclusions to apply.
-        tenant: The name of the tenant being deployed to.
-
-    Returns:
-        The compiled KQL query string with applicable let statements prepended
-        and exclusion filter fragments appended.
-    """
-    # Use a dict to map variable names to their pre-formatted KQL literals.
-    # Dict order (Python 3.7+) preserves declaration order; later definitions
-    # for the same variable name overwrite earlier ones (last-write-wins) to
-    # prevent duplicate KQL let declarations, which would be a compile error.
-    let_kql_literals: dict[str, str] = {}
-    exclusion_queries: list[str] = []
-
-    if exclusions:
-        for exclusion in exclusions:
-            if (exclusion.tenant == tenant) or (not exclusion.tenant):
-                log("INFO", "Applying exclusion", exclusion.query)
-                exclusion_queries.append(exclusion.query)
-
-                if exclusion.let:
-                    for variable, value in exclusion.let.items():
-                        if isinstance(value, bool):
-                            formatted_value = "true" if value else "false"
-                        elif isinstance(value, (int, float)):
-                            formatted_value = str(value)
-                        elif isinstance(value, str):
-                            formatted_value = f'"{value}"'
-                        else:
-                            log("WARNING",
-                                f"Unsupported type for KQL let variable '{variable}'",
-                                f"Got {type(value).__name__}, expected str, int, float or bool — skipping")
-                            continue
-                        let_kql_literals[variable] = formatted_value
-
-    let_statements = []
-    for var, val in let_kql_literals.items():
-        statement = f"let {var} = {val};"
-        log("INFO", "Applying let statement", statement)
-        let_statements.append(statement)
-
-    query = base_query
-    if let_statements:
-        query = "\n".join(let_statements) + "\n" + query
-    if exclusion_queries:
-        query = query + "\n" + "\n".join(exclusion_queries)
-
-    return query
 
 
 def make_deploy_plan(

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -20,7 +20,7 @@ import os
 import git
 import yaml
 import re
-from typing import MutableMapping, Sequence
+from typing import MutableMapping, Optional, Sequence
 from enum import Enum, auto
 from pathlib import Path
 from dataclasses import asdict, dataclass
@@ -141,6 +141,78 @@ def check_status(status_name:str)->StatusStrategy:
         f"Requested status : {status_name}",
         f"Available statuses in deployment.toml : {statuses_definitions}")
     raise Exception
+
+
+def compile_kql_query(
+    base_query: str,
+    exclusions: Optional[Sequence],
+    tenant: str,
+) -> str:
+    """Compile a KQL query by prepending let statements and appending exclusion filters.
+
+    Iterates through the provided exclusions and, for each one that matches the
+    given tenant (or has no tenant specified), collects its ``let`` variable
+    assignments and its filter fragment.  Let statements are prepended to the
+    base query in the order they appear; exclusion filter fragments are appended
+    in the same order.
+
+    If the same variable name is declared across multiple exclusions, the last
+    definition takes precedence (last-write-wins) to prevent duplicate ``let``
+    declarations which would cause a KQL compile error.
+
+    Args:
+        base_query: The base KQL query string to build upon.
+        exclusions: A sequence of exclusion objects exposing ``tenant``,
+            ``let``, and ``query`` attributes, or ``None`` when there are no
+            exclusions to apply.
+        tenant: The name of the tenant being deployed to.
+
+    Returns:
+        The compiled KQL query string with applicable let statements prepended
+        and exclusion filter fragments appended.
+    """
+    # Use a dict to map variable names to their pre-formatted KQL literals.
+    # Dict order (Python 3.7+) preserves declaration order; later definitions
+    # for the same variable name overwrite earlier ones (last-write-wins) to
+    # prevent duplicate KQL let declarations, which would be a compile error.
+    let_kql_literals: dict[str, str] = {}
+    exclusion_queries: list[str] = []
+
+    if exclusions:
+        for exclusion in exclusions:
+            if (exclusion.tenant == tenant) or (not exclusion.tenant):
+                log("INFO", "Applying exclusion", exclusion.query)
+                exclusion_queries.append(exclusion.query)
+
+                if exclusion.let:
+                    for variable, value in exclusion.let.items():
+                        if isinstance(value, bool):
+                            formatted_value = "true" if value else "false"
+                        elif isinstance(value, (int, float)):
+                            formatted_value = str(value)
+                        elif isinstance(value, str):
+                            formatted_value = f'"{value}"'
+                        else:
+                            log("WARNING",
+                                f"Unsupported type for KQL let variable '{variable}'",
+                                f"Got {type(value).__name__}, expected str, int, float or bool — skipping")
+                            continue
+                        let_kql_literals[variable] = formatted_value
+
+    let_statements = []
+    for var, val in let_kql_literals.items():
+        statement = f"let {var} = {val};"
+        log("INFO", "Applying let statement", statement)
+        let_statements.append(statement)
+
+    query = base_query
+    if let_statements:
+        query = "\n".join(let_statements) + "\n" + query
+    if exclusion_queries:
+        query = query + "\n" + "\n".join(exclusion_queries)
+
+    return query
+
 
 def make_deploy_plan(
     plan: DeploymentStrategy,

--- a/Engines/modules/models.py
+++ b/Engines/modules/models.py
@@ -425,8 +425,8 @@ class TideModels:
                 class Exclusion:
                     query: str
                     reason: str
-                    let: Optional[Mapping[str,str]]
-                    tenant: Optional[str]=None
+                    tenant: Optional[str] = None
+                    let: Optional[Mapping[str, Any]] = None
                     
                 schema: str
                 alert: Alert
@@ -544,8 +544,8 @@ class TideModels:
                 class Exclusion:
                     query: str
                     reason: str
-                    let: Optional[Mapping[str,str]]
-                    tenant: Optional[str]=None
+                    tenant: Optional[str] = None
+                    let: Optional[Mapping[str, Any]] = None
 
                 query: str
                 scheduling: Scheduling

--- a/Engines/modules/models.py
+++ b/Engines/modules/models.py
@@ -425,6 +425,7 @@ class TideModels:
                 class Exclusion:
                     query: str
                     reason: str
+                    let: Optional[Mapping[str,str]]
                     tenant: Optional[str]=None
                     
                 schema: str
@@ -539,9 +540,17 @@ class TideModels:
                     entity: str
                     mappings: Sequence[MappingEntry]
 
+                @dataclass
+                class Exclusion:
+                    query: str
+                    reason: str
+                    let: Optional[Mapping[str,str]]
+                    tenant: Optional[str]=None
+
                 query: str
                 scheduling: Scheduling
                 alert: Alert
+                exclusions: Optional[Sequence[Exclusion]] = None
                 template: Optional[Template] = None
                 trigger: Optional[Trigger] = None
                 grouping: Optional[Grouping] = None

--- a/Engines/modules/systems/kql.py
+++ b/Engines/modules/systems/kql.py
@@ -1,0 +1,74 @@
+from typing import Optional, Sequence
+
+from Engines.modules.logs import log
+
+
+def compile_kql_query(
+    base_query: str,
+    exclusions: Optional[Sequence],
+    tenant: str,
+) -> str:
+    """Compile a KQL query by prepending let statements and appending exclusion filters.
+
+    Iterates through the provided exclusions and, for each one that matches the
+    given tenant (or has no tenant specified), collects its ``let`` variable
+    assignments and its filter fragment.  Let statements are prepended to the
+    base query in the order they appear; exclusion filter fragments are appended
+    in the same order.
+
+    If the same variable name is declared across multiple exclusions, the last
+    definition takes precedence (last-write-wins) to prevent duplicate ``let``
+    declarations which would cause a KQL compile error.
+
+    Args:
+        base_query: The base KQL query string to build upon.
+        exclusions: A sequence of exclusion objects exposing ``tenant``,
+            ``let``, and ``query`` attributes, or ``None`` when there are no
+            exclusions to apply.
+        tenant: The name of the tenant being deployed to.
+
+    Returns:
+        The compiled KQL query string with applicable let statements prepended
+        and exclusion filter fragments appended.
+    """
+    # Use a dict to map variable names to their pre-formatted KQL literals.
+    # Dict order (Python 3.7+) preserves declaration order; later definitions
+    # for the same variable name overwrite earlier ones (last-write-wins) to
+    # prevent duplicate KQL let declarations, which would be a compile error.
+    let_kql_literals: dict[str, str] = {}
+    exclusion_queries: list[str] = []
+
+    if exclusions:
+        for exclusion in exclusions:
+            if (exclusion.tenant == tenant) or (not exclusion.tenant):
+                log("INFO", "Applying exclusion", exclusion.query)
+                exclusion_queries.append(exclusion.query)
+
+                if exclusion.let:
+                    for variable, value in exclusion.let.items():
+                        if isinstance(value, bool):
+                            formatted_value = "true" if value else "false"
+                        elif isinstance(value, (int, float)):
+                            formatted_value = str(value)
+                        elif isinstance(value, str):
+                            formatted_value = f'"{value}"'
+                        else:
+                            log("WARNING",
+                                f"Unsupported type for KQL let variable '{variable}'",
+                                f"Got {type(value).__name__}, expected str, int, float or bool — skipping")
+                            continue
+                        let_kql_literals[variable] = formatted_value
+
+    let_statements = []
+    for var, val in let_kql_literals.items():
+        statement = f"let {var} = {val};"
+        log("INFO", "Applying let statement", statement)
+        let_statements.append(statement)
+
+    query = base_query
+    if let_statements:
+        query = "\n".join(let_statements) + "\n" + query
+    if exclusion_queries:
+        query = query + "\n" + "\n".join(exclusion_queries)
+
+    return query

--- a/Engines/modules/systems/kql.py
+++ b/Engines/modules/systems/kql.py
@@ -1,11 +1,16 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from Engines.modules.logs import log
+from Engines.modules.models import TideModels
+
+MDE_Exclusion = TideModels.MDR.Configurations.DefenderForEndpoint.Exclusion
+Sentinel_Exclusion = TideModels.MDR.Configurations.Sentinel.Exclusion
+KQLExclusion = Union[MDE_Exclusion, Sentinel_Exclusion]
 
 
 def compile_kql_query(
     base_query: str,
-    exclusions: Optional[Sequence],
+    exclusions: Optional[Sequence[KQLExclusion]],
     tenant: str,
 ) -> str:
     """Compile a KQL query by prepending let statements and appending exclusion filters.

--- a/Engines/modules/tide.py
+++ b/Engines/modules/tide.py
@@ -462,6 +462,13 @@ class SystemLoader:
                     )
                 )
 
+        exclusions = mdr_config.pop("exclusions", None)
+        if exclusions:
+            exclusions_data = []
+            for exclusion in exclusions:
+                exclusions_data.append(Sentinel.Exclusion(**exclusion))
+            exclusions = exclusions_data
+
         return Sentinel(
             schema=base_config.schema,
             status=base_config.status,
@@ -474,7 +481,8 @@ class SystemLoader:
             scheduling=scheduling,
             alert=alert,
             grouping=grouping,
-            entities=entities
+            entities=entities,
+            exclusions=exclusions
         )
 
     @staticmethod

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Defender for Endpoint.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Defender for Endpoint.yaml
@@ -22,7 +22,8 @@ properties:
     title: Schema identifier and version
     type: string
     description: Identifier of the schema at its current version 
-    const: defender_for_endpoint::2.0
+    default: defender_for_endpoint::2.1
+    tide.template.force-required: True
 
   status: 
     title: Status of the use-case
@@ -518,8 +519,22 @@ properties:
           tide.template.multiline: true
           tide.template.config.default: schema.templates.mdr::exclusions::reason
 
+        let:
+          title: KQL let bindings
+          description: |
+            Optional map of KQL variables to be declared for this exclusion. Each
+            key will be emitted as a `let` statement and can be referenced in the
+            `query` field. Values must be strings and will be inserted verbatim.
+          type: object
+          tide.template.spacer: False
+          patternProperties:
+            "^[A-Za-z0-9_-]+$":
+              example: variable
+              type: string
+          additionalProperties: False
+
         query:
-          title: Exclusion Query 
+          title: Exclusion KQL 
           type: string
           description: |
             Write here the exclusion query, that will be appended to the base query

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Microsoft Sentinel.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Microsoft Sentinel.yaml
@@ -34,7 +34,7 @@ properties:
     title: Schema identifier and version
     type: string
     description: Identifier of the schema at its current version 
-    default: sentinel::2.3
+    default: sentinel::2.4
     tide.template.force-required: True
 
   status: 
@@ -1923,3 +1923,58 @@ properties:
     tide.template.spacer: true # Forces the template synthesis to add a space
     description: Scheduled query in KQL language
     example: 'SignInLogs | evaluate bag_unpack(LocationDetails)'
+
+  exclusions:
+    title: Tenant-Scoped Exclusions
+    type: array
+    description: |
+      This section adds exclusions, using queries that will be appended to the final
+      query deployed in a per-tenant fashion, and fully documented.
+      You may remove the tenant field, in which case the exclusion will apply to all
+      tenants.
+      You may add multiple exclusion section for the same tenant - in which case they 
+      will be appended in the order that they appear. 
+    tide.template.spacer: true 
+    items:
+      type: object
+      required:
+        - reason
+        - query
+      properties:
+        tenant:
+          title: Tenant
+          type: string
+          description: |
+            The tenant to which the exclusion applied. Remove if the exclusion should
+            be applied to all tenants. 
+          tide.config.system.tenants: defender_for_endpoint
+        
+        reason:
+          title: Exclusion Reason
+          type: string
+          description: |
+            Document why the exclusion was added
+          tide.template.multiline: true
+          tide.template.config.default: schema.templates.mdr::exclusions::reason
+
+        let:
+          title: KQL let bindings
+          description: |
+            Optional map of KQL variables to be declared for this exclusion. Each
+            key will be emitted as a `let` statement and can be referenced in the
+            `query` field. Values must be strings and will be inserted verbatim.
+          type: object
+          tide.template.spacer: False
+          patternProperties:
+            "^[A-Za-z0-9_-]+$":
+              example: variable
+              type: string
+          additionalProperties: False
+
+        query:
+          title: Exclusion KQL 
+          type: string
+          description: |
+            Write here the exclusion query, that will be appended to the base query
+          tide.template.multiline: true
+          tide.template.no-space: true

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Microsoft Sentinel.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Microsoft Sentinel.yaml
@@ -1947,7 +1947,7 @@ properties:
           description: |
             The tenant to which the exclusion applied. Remove if the exclusion should
             be applied to all tenants. 
-          tide.config.system.tenants: defender_for_endpoint
+          tide.config.system.tenants: sentinel
         
         reason:
           title: Exclusion Reason

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Templates/Microsoft Defender for Endpoint Template.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Templates/Microsoft Defender for Endpoint Template.yaml
@@ -1,4 +1,4 @@
-  schema: defender_for_endpoint::2.0
+  schema: defender_for_endpoint::2.1
   status: 
   #contributors:
     #-
@@ -61,5 +61,7 @@
     #- tenant: 
       #reason: |
         #...
+      #let:
+        #variable: 
       #query: |
         #...

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Templates/Microsoft Sentinel Template.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Templates/Microsoft Sentinel Template.yaml
@@ -1,4 +1,4 @@
-  schema: sentinel::2.3
+  schema: sentinel::2.4
   status: 
   #contributors:
     #-
@@ -53,3 +53,12 @@
   
   query: |
     ...
+  
+  #exclusions:
+    #- tenant: 
+      #reason: |
+        #...
+      #let:
+        #variable: 
+      #query: |
+        #...


### PR DESCRIPTION
## Summary

Extends KQL exclusion support with `let` variable declarations and generalises the exclusion mechanism to both Microsoft Sentinel and Defender for Endpoint deployers.

Closes #31

## Problem

The exclusion system previously only supported Defender for Endpoint and was limited to appending raw query fragments. This made it difficult to inject reusable variables (e.g. thresholds, entity lists) without awkward query positioning hacks. Additionally, Sentinel had no exclusion support at all.

## Changes

### Schema (`defender_for_endpoint::2.1`, `sentinel::2.4`)
- **Defender for Endpoint**: Added `let` field to the existing exclusion schema; bumped version from `2.0` → `2.1`; changed `const` to `default` with `tide.template.force-required`
- **Microsoft Sentinel**: Added the full `exclusions` section (tenant-scoped, with `let` support) mirroring the MDE exclusion structure; bumped version from `2.3` → `2.4`
- **Templates**: Both MDE and Sentinel templates updated with new schema versions and `let` field examples

### KQL compilation module (`Engines/modules/systems/kql.py`)
New `compile_kql_query(base_query, exclusions, tenant)` in a dedicated KQL module replaces duplicated inline logic:
- `let` bindings prepended to the query in declaration order
- Exclusion filter fragments appended in YAML declaration order
- Last-write-wins deduplication on variable names (prevents KQL compile errors from duplicate `let` declarations)
- Type-aware formatting: strings quoted, numbers/bools unquoted, unsupported types logged and skipped
- Properly typed using `Union[MDE_Exclusion, Sentinel_Exclusion]` from existing model definitions

### Deployers
- **`defender_for_endpoint.py`**: Inline exclusion loop replaced with `compile_kql_query()` call; removed debug `print(query)`
- **`sentinel.py`**: Added `tenant` parameter to `compile_deployment()`; integrated `compile_kql_query()` for exclusion support

### Data models (`Engines/modules/models.py`, `Engines/modules/tide.py`)
- `Exclusion` dataclass gains `let: Optional[Mapping[str, Any]]` on both MDE and Sentinel configs
- Sentinel `tide.py` parser extended to deserialise the new `exclusions` field

### Bug fix
- Fixed copy-paste error in the Sentinel exclusion schema where `tide.config.system.tenants` was incorrectly referencing `defender_for_endpoint` instead of `sentinel`

## Example

```yaml
exclusions:
  - tenant: Prod
    let:
      threshold: 10
      region: "West Europe"
    reason: |
      Exclude known region below threshold
    query: |
      | where Region != region
      | where Count < threshold
```

Compiles to:

```kql
let threshold = 10;
let region = "West Europe";
<base query>
| where Region != region
| where Count < threshold
```