### PR TITLE
Simplify column renaming in table_export.py

### DIFF
--- a/Engines/export/table_export.py
+++ b/Engines/export/table_export.py
@@ -51,11 +51,7 @@ class TableExporter:
     def _rename_columns(self, dataset:pd.DataFrame)->pd.DataFrame:
         new_columns = {}
         for column in dataset.columns:
-            if column == "actors":
-                new_columns[column] = "Threat Actors"
-            elif column == "attack":
-                new_columns[column] = "ATT&CK"
-            elif column == "uuid":
+            if column == "uuid":
                 new_columns[column] = "UUID"
             else:
                 new_columns[column] = column.capitalize()


### PR DESCRIPTION
Refactor column renaming logic in _rename_columns method to keep alphanumeric names without spaces or specific characters