### PR TITLE
feat: support alert descriptions in defender for endpoint

### DIFF
--- a/Engines/deployment/defender_for_endpoint.py
+++ b/Engines/deployment/defender_for_endpoint.py
@@ -22,8 +22,6 @@ from Engines.modules.systems.defender_for_endpoint import (DetectionRule,
     
 
 
-
-
 class DefenderForEndpointDeploy(DeployMDR):
     
     def deploy_mdr(self, data:TideModels.MDR, service:DefenderForEndpointService, tenant:str):
@@ -127,17 +125,23 @@ class DefenderForEndpointDeploy(DeployMDR):
 
         # Remove spaces in category
         category = mdr_config.alert.category.replace(" ", "")
+        
+        # Handle Alert description
+        alert_description = mdr_config.alert.description or data.description
 
+        # Compile Alert Template
         alert_template = DetectionRule.DetectionAction.AlertTemplate(title = mdr_config.alert.title or data.name,
-                                                                    description=data.description,
+                                                                    description=alert_description,
                                                                     severity=severity, 
                                                                     category=category,
                                                                     mitreTechniques=[],
                                                                     impactedAssets=impacted_assets,
                                                                     recommendedActions=mdr_config.alert.recommendation or None)
 
+        # Handle Scheduling
         scheduling = mdr_config.scheduling if mdr_config.scheduling != "NRT" else "0"
         
+        # Check if the rule is enabled or disabled
         is_enabled = False if check_status(mdr_config.status) is StatusStrategy.DISABLEMENT else True
         
         # Handle Query and Exclusions
@@ -153,6 +157,7 @@ class DefenderForEndpointDeploy(DeployMDR):
         log("INFO", "Final compiled query")
         print(query)
 
+        # Compile Detection Rule
         rule = DetectionRule(displayName=data.name,
                             isEnabled=is_enabled,
                             queryCondition=DetectionRule.QueryCondition(queryText=query),

--- a/Engines/modules/models.py
+++ b/Engines/modules/models.py
@@ -365,6 +365,7 @@ class TideModels:
                 class Alert:
                     category: str
                     title: Optional[str] = None
+                    description: Optional[str] = None
                     severity: Optional[str] = None
                     recommendation: Optional[str] = None
                     techniques: Optional[Sequence[str]] = None

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Defender for Endpoint.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Defender for Endpoint.yaml
@@ -88,11 +88,24 @@ properties:
 
       title:
         title: Alert Title
+        type: string
         tide.mdr.parameter: detectionAction.alertTemplate.title
         description: |
           Name of the alert triggered by the custom detection rule. By
           default, the name of the MDR will be used, but this parameter allows
           to override it. 
+
+      description:
+        title: Alert Description
+        type: string
+        tide.mdr.parameter: detectionAction.alertTemplate.description
+        description: |
+          Detailed description of the alert triggered by the custom detection rule.
+          This text provides context about the detection and helps analysts understand
+          the nature of the threat.
+
+          By default, the description of the MDR will be used, but this parameter
+          allows to override it.
 
       category:
         title: Threat Category


### PR DESCRIPTION
Add missing support for alert descriptions in MDE where they were previously missing.