### PR TITLE
Warn if there is no parent commit instead of failed execution (expected for the initial commit) and exit gracefully

### DIFF
--- a/Pipelines/GitHub/check-mdr-changes/action.yml
+++ b/Pipelines/GitHub/check-mdr-changes/action.yml
@@ -14,7 +14,8 @@ runs:
         # Ensure the parent commit exists
         if ! git rev-parse HEAD^ >/dev/null 2>&1; then
           echo "::warning::Cannot compute diff because HEAD has no parent commit."
-          echo "::warning::This usually happens with shallow clones (fetch-depth=1) or the first repository commit."
+          echo "::warning::This usually happens when the InitTide template is cloned for the first time and is expected. On subsequent commits, this should not appear."
+          echo "::warning::On subsequent commits, this should not appear."
           echo "CHANGES=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/Pipelines/GitHub/check-mdr-changes/action.yml
+++ b/Pipelines/GitHub/check-mdr-changes/action.yml
@@ -14,7 +14,7 @@ runs:
         # Ensure the parent commit exists
         if ! git rev-parse HEAD^ >/dev/null 2>&1; then
           echo "::warning::Cannot compute diff because HEAD has no parent commit."
-          echo "::warning::This usually happens when the InitTide template is cloned for the first time and is expected. On subsequent commits, this should not appear."
+          echo "::warning::This usually happens when the InitTide template is cloned for the first time and is expected."
           echo "::warning::On subsequent commits, this should not appear."
           echo "CHANGES=false" >> "$GITHUB_OUTPUT"
           exit 0

--- a/Pipelines/GitHub/check-mdr-changes/action.yml
+++ b/Pipelines/GitHub/check-mdr-changes/action.yml
@@ -11,12 +11,21 @@ runs:
       id: detect_mdr_changes
       shell: bash
       run: |
-          # List files changed in the last commit
-          CHANGED=$(git diff --name-only HEAD^ HEAD)
-          echo "Changed files: $CHANGED"
-          # Grep for the directory with a leading ^ to avoid false positives
-          if echo "$CHANGED" | grep -q '^Objects/Detection Rules/'; then
-            echo "CHANGES=true" >> $GITHUB_OUTPUT
-          else
-            echo "CHANGES=false" >> $GITHUB_OUTPUT
-          fi
+        # Ensure the parent commit exists
+        if ! git rev-parse HEAD^ >/dev/null 2>&1; then
+          echo "::warning::Cannot compute diff because HEAD has no parent commit."
+          echo "::warning::This usually happens with shallow clones (fetch-depth=1) or the first repository commit."
+          echo "CHANGES=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # List files changed in the last commit
+        CHANGED=$(git diff --name-only HEAD^ HEAD)
+        echo "Changed files: $CHANGED"
+
+        # Grep for the directory with a leading ^ to avoid false positives
+        if echo "$CHANGED" | grep -q '^Objects/Detection Rules/'; then
+          echo "CHANGES=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "CHANGES=false" >> "$GITHUB_OUTPUT"
+        fi


### PR DESCRIPTION
Summary

This change makes the Pipelines/GitHub/check-mdr-changes/action.yml workflow resilient when there is no parent commit (e.g., in the repository’s initial commit or when using a shallow clone with fetch-depth: 1). Previously the script would fail trying to diff HEAD^, causing the workflow to error.
What changed

    Added a guard that checks whether HEAD^ exists before attempting a diff.
    If the parent commit is missing, the step now emits a warning and sets CHANGES=false without failing.

Why this matters

GitHub Actions runners often use shallow clones by default or may run on a repository with only a single commit. This patch prevents false negatives and hard failures in those cases.
Testing

    Verified the workflow runs cleanly when the repository has a parent commit.
    Verified the workflow exits gracefully (with a warning) when HEAD has no parent.
