### PR TITLE
Make proxy credentials optional in Proxy.set_proxy

### DIFF
--- a/Configurations/deployment.toml
+++ b/Configurations/deployment.toml
@@ -47,6 +47,8 @@ enabled = true
 promotion_target = "PRODUCTION"
 
 [proxy]
+# proxy_user and proxy_password are optional: if both are present, auth is used,
+# otherwise the proxy is configured with host:port only
 proxy_user = "$PROXY_USER"
 proxy_password = "$PROXY_PASSWORD"
 proxy_host = "$PROXY_HOST"

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -524,8 +524,12 @@ def enabled_systems() -> list[str]:
 
 class Proxy:
     """
-    Simple class to encapulate configuring the proxy in
-    environment variables
+    Encapsulates proxy setup for environment variables.
+
+    Behavior:
+    - Requires proxy_host and proxy_port
+    - Uses proxy_user / proxy_password only when both are provided
+    - Supports unauthenticated proxy URLs for hosts behind transparent proxies
     """
 
     @staticmethod

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -546,22 +546,22 @@ class Proxy:
         proxy_host = PROXY_CONFIG.get("proxy_host")
         proxy_port = PROXY_CONFIG.get("proxy_port")
 
-            if proxy_host and proxy_port:
-                if proxy_user and proxy_pass:
-                    proxy = f"http://{proxy_user}:{proxy_pass}@{proxy_host}:{proxy_port}"
-                else:
-                    proxy = f"http://{proxy_host}:{proxy_port}"
-
-                os.environ["HTTP_PROXY"] = proxy
-                os.environ["HTTPS_PROXY"] = proxy
-                log("SUCCESS", "Proxy environment setup successful")
+        if proxy_host and proxy_port:
+            if proxy_user and proxy_pass:
+                proxy = f"http://{proxy_user}:{proxy_pass}@{proxy_host}:{proxy_port}"
             else:
-                log(
-                    "FAILURE",
-                    "Could not retrieve mandatory proxy host and port",
-                    "Control that proxy_host and proxy_port are entered in CI variables",
-                    "proxy_user and proxy_password are optional",
-                )
+                proxy = f"http://{proxy_host}:{proxy_port}"
+
+            os.environ["HTTP_PROXY"] = proxy
+            os.environ["HTTPS_PROXY"] = proxy
+            log("SUCCESS", "Proxy environment setup successful")
+        else:
+            log(
+                "FAILURE",
+                "Could not retrieve mandatory proxy host and port",
+                "Control that proxy_host and proxy_port are entered in CI variables",
+                "proxy_user and proxy_password are optional",
+            )
 
     @staticmethod
     def unset_proxy():

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -536,21 +536,26 @@ class Proxy:
             log("ONGOING", "Setting environment proxy according to CI variables")
             PROXY_CONFIG = DataTide.Configurations.Deployment.proxy
             PROXY_CONFIG = HelperTide.fetch_config_envvar(PROXY_CONFIG)
-            proxy_user = PROXY_CONFIG["proxy_user"]
-            proxy_pass = PROXY_CONFIG["proxy_password"]
-            proxy_host = PROXY_CONFIG["proxy_host"]
-            proxy_port = PROXY_CONFIG["proxy_port"]
-            if proxy_host and proxy_port and proxy_user and proxy_pass:
-                proxy = f"http://{proxy_user}:{proxy_pass}@{proxy_host}:{proxy_port}"
+            proxy_user = PROXY_CONFIG.get("proxy_user")
+            proxy_pass = PROXY_CONFIG.get("proxy_password")
+            proxy_host = PROXY_CONFIG.get("proxy_host")
+            proxy_port = PROXY_CONFIG.get("proxy_port")
+
+            if proxy_host and proxy_port:
+                if proxy_user and proxy_pass:
+                    proxy = f"http://{proxy_user}:{proxy_pass}@{proxy_host}:{proxy_port}"
+                else:
+                    proxy = f"http://{proxy_host}:{proxy_port}"
+
                 os.environ["HTTP_PROXY"] = proxy
                 os.environ["HTTPS_PROXY"] = proxy
                 log("SUCCESS", "Proxy environment setup successful")
             else:
                 log(
                     "FAILURE",
-                    "Could not retrieve all proxy information",
-                    "Control that all proxy infos are entered in CI variables",
-                    "Expects proxy_user, proxy_password, proxy_host and proxy_port",
+                    "Could not retrieve mandatory proxy host and port",
+                    "Control that proxy_host and proxy_port are entered in CI variables",
+                    "proxy_user and proxy_password are optional",
                 )
 
     @staticmethod

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -524,22 +524,27 @@ def enabled_systems() -> list[str]:
 
 class Proxy:
     """
-    Simple class to encapulate configuring the proxy in
-    environment variables
+    Encapsulates proxy setup for environment variables.
+
+    Behavior:
+    - Requires proxy_host and proxy_port
+    - Uses proxy_user / proxy_password only when both are provided
+    - Supports unauthenticated proxy URLs for hosts behind transparent proxies
     """
 
     @staticmethod
     def set_proxy():
         if DebugEnvironment.ENABLED and not DebugEnvironment.PROXY_ENABLED:
-            pass
-        else:
-            log("ONGOING", "Setting environment proxy according to CI variables")
-            PROXY_CONFIG = DataTide.Configurations.Deployment.proxy
-            PROXY_CONFIG = HelperTide.fetch_config_envvar(PROXY_CONFIG)
-            proxy_user = PROXY_CONFIG.get("proxy_user")
-            proxy_pass = PROXY_CONFIG.get("proxy_password")
-            proxy_host = PROXY_CONFIG.get("proxy_host")
-            proxy_port = PROXY_CONFIG.get("proxy_port")
+            # Debug mode explicitly has proxy setup disabled
+            return
+
+        log("ONGOING", "Setting environment proxy according to CI variables")
+        PROXY_CONFIG = DataTide.Configurations.Deployment.proxy
+        PROXY_CONFIG = HelperTide.fetch_config_envvar(PROXY_CONFIG)
+        proxy_user = PROXY_CONFIG.get("proxy_user")
+        proxy_pass = PROXY_CONFIG.get("proxy_password")
+        proxy_host = PROXY_CONFIG.get("proxy_host")
+        proxy_port = PROXY_CONFIG.get("proxy_port")
 
             if proxy_host and proxy_port:
                 if proxy_user and proxy_pass:


### PR DESCRIPTION
"Proxy.env now works with unauthenticated proxies plus optional user/pass."
"No config break; old behavior preserved when auth fully provided."
"Deployment docs updated in deployment.to