### PR TITLE
feat(carbon-black): Migrate CBC deployer to MDRv4 typed framework

### DIFF
--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -1,6 +1,5 @@
 ---
 description: "Use when creating commits, branches, pull requests, issues, or any Git/GitHub workflow operations. Covers conventional commits, branching strategy, PR standards, and issue management."
-applyTo: ""
 ---
 
 # Git Workflow & Conventional Commits

--- a/Configurations/systems/carbon_black_cloud.toml
+++ b/Configurations/systems/carbon_black_cloud.toml
@@ -1,3 +1,39 @@
+# === New MDRv4 Format ===
+
+[platform]
+enabled = false
+identifier = "carbon_black_cloud"
+name = "Carbon Black Cloud Enterprise EDR"
+subschema = "CBC EDR Sub Schema"
+description = """VMware Carbon Black Enterprise EDR is an advanced threat hunting
+and incident response solution delivering continuous visibility for top security
+operations centres (SOCs) and incident response (IR) teams."""
+flags = []
+
+# [[tenants]]
+# name = "org_name"
+# description = "Organisation description"
+# deployment = "PRODUCTION"
+# [tenants.setup]
+# proxy = false
+# ssl = true
+# url = "$CBC_URL"
+# org_key = "$CBC_ORG_KEY"
+# token = "$CBC_TOKEN"
+# watchlist = "CoreTide"
+# organizations = []
+
+# [[modifiers]]
+# name = "example_modifier"
+# description = "Example deployment modifier"
+# [modifiers.conditions]
+# status = ["Production"]
+# [modifiers.modifications]
+# key = "value"
+
+# === Legacy Format (deprecated) ===
+# TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Remove after full migration
+
 [tide]
 enabled = false
 identifier = "carbon_black_cloud"

--- a/Configurations/systems/carbon_black_cloud.toml
+++ b/Configurations/systems/carbon_black_cloud.toml
@@ -41,7 +41,7 @@ name = "Carbon Black Cloud Enterprise EDR"
 subschema = "CBC EDR Sub Schema"
 description = """VMware Carbon Black Enterprise EDR is an advanced threat hunting
 and incident response solution delivering continuous visibility for top security
-operations centers (SOCs) and incident response (IR) teams."""
+operations centres (SOCs) and incident response (IR) teams."""
 
 [setup]
 proxy = false

--- a/Engines/deployment/carbon_black_cloud.py
+++ b/Engines/deployment/carbon_black_cloud.py
@@ -290,10 +290,10 @@ class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
                     ssl_verify=self.SSL_ENABLED
                 )
                 log("SUCCESS", "Successfully connected to Carbon Black Cloud on tenant", org)
-            except Exception:
+            except Exception as e:
                 raise Exception(
                     f"⚠️ [FAILURE] Service could not be reached for organisation {org}"
-                )
+                ) from e
 
             uuid = mdr.metadata.uuid
             name = mdr.name.strip()
@@ -408,6 +408,15 @@ class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
 
         if mdr_deployment is not None:
             # MDRv4 typed deployment path
+            # Normalise string UUIDs to typed MDR objects (orchestrator passes UUIDs)
+            loaded_mdr = []
+            for mdr in mdr_deployment:
+                if type(mdr) is str:
+                    loaded_mdr.append(DataTide.Models.MDR[mdr])
+                elif type(mdr) is TideModels.MDR:
+                    loaded_mdr.append(mdr)
+            mdr_deployment = loaded_mdr
+
             if not mdr_deployment:
                 log("SKIP", "No MDRs to deploy for Carbon Black Cloud")
                 return

--- a/Engines/deployment/carbon_black_cloud.py
+++ b/Engines/deployment/carbon_black_cloud.py
@@ -13,7 +13,9 @@ from Engines.modules.tide import DataTide
 from Engines.modules.plugins import DeployMDR
 from Engines.modules.carbon_black_cloud import CarbonBlackCloudEngineInit
 from Engines.modules.deployment import check_status
-from Engines.modules.models import StatusStrategy
+from Engines.modules.models import StatusStrategy, DeploymentStrategy, TideModels
+
+from typing import Sequence, Optional
 
 class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
 
@@ -241,26 +243,197 @@ class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
 
         return True
 
-    def deploy(self, deployment: list[str]):
+    def deploy_mdr_v4(self, mdr: TideModels.MDR):
+        """MDRv4 typed deployment routine for a single MDR object.
 
-        if not deployment:
-            raise Exception("DEPLOYMENT NOT FOUND")
+        Uses typed attribute access instead of dict-based access.
+        """
+
+        config = mdr.configurations.carbon_black_cloud
+        if not config or not hasattr(config, "query"):
+            log("SKIP", "MDR does not contain a typed CBC configuration", mdr.name)
+            return
+
+        custom_orgs = config.organizations
+        deploy_orgs = custom_orgs if custom_orgs else self.ORGANIZATIONS
+
+        for org in deploy_orgs:
+            log("ONGOING", f"Currently deploying MDR {mdr.name} on organisation", org)
+
+            org = org.strip()
+            if org in self.CBC_SECRETS:
+                org_secrets = self.CBC_SECRETS[org]
+                org_key = org_secrets.get("org_key")
+                token = org_secrets.get("token")
+            else:
+                log(
+                    "FATAL",
+                    "Target organisation is not present in Secrets configuration",
+                    org,
+                    "Double check TOML config to ensure there is an org_key and token entry for this org",
+                )
+                raise Exception("Organisation not found in secrets")
+
+            if not org_key or not token:
+                log(
+                    "FATAL",
+                    "Missing org_key or token for organisation",
+                    org,
+                )
+                raise Exception("Missing credentials")
+
+            try:
+                service = CBCloudAPI(
+                    url=self.CBC_URL,
+                    token=token,
+                    org_key=org_key,
+                    ssl_verify=self.SSL_ENABLED
+                )
+                log("SUCCESS", "Successfully connected to Carbon Black Cloud on tenant", org)
+            except Exception:
+                raise Exception(
+                    f"⚠️ [FAILURE] Service could not be reached for organisation {org}"
+                )
+
+            uuid = mdr.metadata.uuid
+            name = mdr.name.strip()
+            description = mdr.description.strip()
+            status = config.status
+            query = config.query.replace("\n", " ")
+
+            deployment_action = False
+            removal = False
+
+            if check_status(status) in (StatusStrategy.DISABLEMENT, StatusStrategy.DELETION):
+                removal = True
+            else:
+                deployment_action = True
+
+            tags = [config.status]
+
+            if mdr.detection_model:
+                techniques = techniques_resolver(uuid)
+                tags.append(mdr.detection_model)
+                tags.extend(techniques)
+
+            if config.tags:
+                tags.extend(config.tags)
+
+            severity = self.SEVERITY_MAPPING[mdr.response.alert_severity]
+
+            selected_watchlist = config.watchlist or self.DEFAULT_WATCHLIST
+            selected_report = config.report or name
+
+            watchlist_list = service.select(Watchlist)
+            report = None
+            watchlist = None
+
+            if watchlist_list:
+                for w in watchlist_list:
+                    if w.name == selected_watchlist:
+                        watchlist = w
+
+                if watchlist:
+                    for r in watchlist.reports:
+                        if r.title == selected_report:
+                            report = r
+                else:
+                    raise Exception(
+                        f"⚠️ [FATAL] The CBC Deployer cannot create a detection in a non-"
+                        f"existent Watchlist: {selected_watchlist}. Make sure to create "
+                        "one on the console before retriggering the deployment"
+                    )
+
+            ioc = IOC_V2.create_query(service, uuid, query)
+
+            if report:
+                if selected_report == name:
+                    if deployment_action:
+                        report.remove_iocs_by_id(str(uuid))
+                        report.append_iocs([ioc])
+                        if severity != report.severity:
+                            report.update(description=description, tags=tags, severity=severity)
+                            log("INFO", "Upgraded severity for this report to align with MDR", str(severity))
+                        else:
+                            report.update(description=description, tags=tags)
+                        log("SUCCESS", "Rolled out IOC to report", selected_report)
+                    elif removal:
+                        report.delete()
+                        log("WARNING", "The report was deleted alongside the rule", selected_report)
+                else:
+                    if deployment_action:
+                        report.remove_iocs_by_id(uuid)
+                        report.append_iocs([ioc])
+                        tags.extend(t for t in report.tags if t not in tags)
+                        if severity > report.severity:
+                            report.update(description=description, tags=tags, severity=severity)
+                            log("INFO", "Upgraded severity for this report to align with MDR", str(severity))
+                        else:
+                            report.update(description=description, tags=tags)
+                        log("SUCCESS", "Deployed IOC to report", selected_report)
+                    elif removal:
+                        if len(report.iocs_) > 1:
+                            report.remove_iocs_by_id(uuid)
+                            report.update()
+                            log("SUCCESS", "Deleted IOC from report", selected_report)
+                        else:
+                            report.delete()
+                            log(
+                                "WARNING",
+                                "The specified report was automatically "
+                                "deleted as there were no other rules",
+                                selected_report,
+                            )
+            else:
+                if deployment_action:
+                    report_builder = Report.create(service, selected_report, description, severity)
+                    report_builder.add_ioc(ioc)
+                    for tag in tags:
+                        report_builder.add_tag(tag.strip())
+                    report = report_builder.build()
+                    report.save_watchlist()
+                    watchlist.add_reports([report])  # type: ignore
+                    log("SUCCESS", "Created report and deployed IOC", selected_report)
+                elif removal:
+                    log("SKIP", "No report to delete, already removed from system", selected_report)
+
+        return True
+
+    def deploy(self,
+               deployment: Optional[list[str]] = None,
+               mdr_deployment: Optional[Sequence[TideModels.MDR]] = None,
+               deployment_plan: Optional[DeploymentStrategy] = None):
 
         self.configure_proxy()
 
-        # Start deployment routine
-        for mdr in deployment:
-            mdr_data = DataTide.Models.mdr[mdr]
+        if mdr_deployment is not None:
+            # MDRv4 typed deployment path
+            if not mdr_deployment:
+                log("SKIP", "No MDRs to deploy for Carbon Black Cloud")
+                return
 
-            # Check if modified MDR contains a platform entry (by safety, but should not happen since orchestrator will filter for the platform)
-            if self.DEPLOYER_IDENTIFIER in mdr_data["configurations"].keys():
-                self.deploy_mdr(mdr_data)
-            else:
-                log(
-                    "SKIP",
-                    f"🛑 Skipping as does not contain a CBC rule",
-                    mdr_data.get("name"),
-                )
+            for mdr in mdr_deployment:
+                if mdr.configurations.carbon_black_cloud and hasattr(mdr.configurations.carbon_black_cloud, "query"):
+                    self.deploy_mdr_v4(mdr)
+                else:
+                    log("SKIP", "🛑 Skipping as does not contain a typed CBC rule", mdr.name)
+
+        else:
+            # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy MDRv3 deployment path
+            if not deployment:
+                raise Exception("DEPLOYMENT NOT FOUND")
+
+            for mdr in deployment:
+                mdr_data = DataTide.Models.mdr[mdr]
+
+                if self.DEPLOYER_IDENTIFIER in mdr_data["configurations"].keys():
+                    self.deploy_mdr(mdr_data)
+                else:
+                    log(
+                        "SKIP",
+                        f"🛑 Skipping as does not contain a CBC rule",
+                        mdr_data.get("name"),
+                    )
 
 
 def declare():

--- a/Engines/deployment/carbon_black_cloud.py
+++ b/Engines/deployment/carbon_black_cloud.py
@@ -9,11 +9,16 @@ sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
 from Engines.modules.framework import techniques_resolver
 from Engines.modules.logs import log
 from Engines.modules.debug import DebugEnvironment
-from Engines.modules.tide import DataTide
+from Engines.modules.tide import DataTide, DetectionSystems
 from Engines.modules.plugins import DeployMDR
 from Engines.modules.carbon_black_cloud import CarbonBlackCloudEngineInit
-from Engines.modules.deployment import check_status
-from Engines.modules.models import StatusStrategy, DeploymentStrategy, TideModels
+from Engines.modules.deployment import TideDeployment, check_status
+from Engines.modules.models import (StatusStrategy,
+                                    DeploymentStrategy,
+                                    TideModels,
+                                    TideConfigs,
+                                    TenantDeployment)
+from Engines.modules.systems.carbon_black_cloud import CarbonBlackCloudService
 
 from typing import Sequence, Optional
 
@@ -243,159 +248,122 @@ class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
 
         return True
 
-    def deploy_mdr_v4(self, mdr: TideModels.MDR):
-        """MDRv4 typed deployment routine for a single MDR object.
+    def deploy_mdr_v4(self,
+                      data: TideModels.MDR,
+                      service: CBCloudAPI,
+                      tenant_config: TideConfigs.Systems.CarbonBlackCloud.Tenant):
+        """MDRv4 typed deployment routine for a single MDR on a single tenant.
 
-        Uses typed attribute access instead of dict-based access.
+        Follows the same architectural pattern as Sentinel, Defender for Endpoint,
+        etc. — each call deploys one MDR to one tenant.
         """
 
-        config = mdr.configurations.carbon_black_cloud
+        config = data.configurations.carbon_black_cloud
         if not config or not hasattr(config, "query"):
-            log("SKIP", "MDR does not contain a typed CBC configuration", mdr.name)
+            log("SKIP", "MDR does not contain a typed CBC configuration", data.name)
             return
 
-        custom_orgs = config.organizations
-        deploy_orgs = custom_orgs if custom_orgs else self.ORGANIZATIONS
+        uuid = data.metadata.uuid
+        name = data.name.strip()
+        description = data.description.strip()
+        status = config.status
+        query = config.query.replace("\n", " ")
 
-        for org in deploy_orgs:
-            log("ONGOING", f"Currently deploying MDR {mdr.name} on organisation", org)
+        deployment_action = False
+        removal = False
 
-            org = org.strip()
-            if org in self.CBC_SECRETS:
-                org_secrets = self.CBC_SECRETS[org]
-                org_key = org_secrets.get("org_key")
-                token = org_secrets.get("token")
+        if check_status(status) in (StatusStrategy.DISABLEMENT, StatusStrategy.DELETION):
+            removal = True
+        else:
+            deployment_action = True
+
+        tags = [config.status]
+
+        if data.detection_model:
+            techniques = techniques_resolver(uuid)
+            tags.append(data.detection_model)
+            tags.extend(techniques)
+
+        if config.tags:
+            tags.extend(config.tags)
+
+        severity = self.SEVERITY_MAPPING[data.response.alert_severity]
+
+        selected_watchlist = config.watchlist or self.DEFAULT_WATCHLIST
+        selected_report = config.report or name
+
+        watchlist_list = service.select(Watchlist)
+        report = None
+        watchlist = None
+
+        if watchlist_list:
+            for w in watchlist_list:
+                if w.name == selected_watchlist:
+                    watchlist = w
+
+            if watchlist:
+                for r in watchlist.reports:
+                    if r.title == selected_report:
+                        report = r
             else:
-                log(
-                    "FATAL",
-                    "Target organisation is not present in Secrets configuration",
-                    org,
-                    "Double check TOML config to ensure there is an org_key and token entry for this org",
-                )
-                raise Exception("Organisation not found in secrets")
-
-            if not org_key or not token:
-                log(
-                    "FATAL",
-                    "Missing org_key or token for organisation",
-                    org,
-                )
-                raise Exception("Missing credentials")
-
-            try:
-                service = CBCloudAPI(
-                    url=self.CBC_URL,
-                    token=token,
-                    org_key=org_key,
-                    ssl_verify=self.SSL_ENABLED
-                )
-                log("SUCCESS", "Successfully connected to Carbon Black Cloud on tenant", org)
-            except Exception as e:
                 raise Exception(
-                    f"⚠️ [FAILURE] Service could not be reached for organisation {org}"
-                ) from e
+                    f"⚠️ [FATAL] The CBC Deployer cannot create a detection in a non-"
+                    f"existent Watchlist: {selected_watchlist}. Make sure to create "
+                    "one on the console before retriggering the deployment"
+                )
 
-            uuid = mdr.metadata.uuid
-            name = mdr.name.strip()
-            description = mdr.description.strip()
-            status = config.status
-            query = config.query.replace("\n", " ")
+        ioc = IOC_V2.create_query(service, uuid, query)
 
-            deployment_action = False
-            removal = False
-
-            if check_status(status) in (StatusStrategy.DISABLEMENT, StatusStrategy.DELETION):
-                removal = True
-            else:
-                deployment_action = True
-
-            tags = [config.status]
-
-            if mdr.detection_model:
-                techniques = techniques_resolver(uuid)
-                tags.append(mdr.detection_model)
-                tags.extend(techniques)
-
-            if config.tags:
-                tags.extend(config.tags)
-
-            severity = self.SEVERITY_MAPPING[mdr.response.alert_severity]
-
-            selected_watchlist = config.watchlist or self.DEFAULT_WATCHLIST
-            selected_report = config.report or name
-
-            watchlist_list = service.select(Watchlist)
-            report = None
-            watchlist = None
-
-            if watchlist_list:
-                for w in watchlist_list:
-                    if w.name == selected_watchlist:
-                        watchlist = w
-
-                if watchlist:
-                    for r in watchlist.reports:
-                        if r.title == selected_report:
-                            report = r
-                else:
-                    raise Exception(
-                        f"⚠️ [FATAL] The CBC Deployer cannot create a detection in a non-"
-                        f"existent Watchlist: {selected_watchlist}. Make sure to create "
-                        "one on the console before retriggering the deployment"
-                    )
-
-            ioc = IOC_V2.create_query(service, uuid, query)
-
-            if report:
-                if selected_report == name:
-                    if deployment_action:
-                        report.remove_iocs_by_id(str(uuid))
-                        report.append_iocs([ioc])
-                        if severity != report.severity:
-                            report.update(description=description, tags=tags, severity=severity)
-                            log("INFO", "Upgraded severity for this report to align with MDR", str(severity))
-                        else:
-                            report.update(description=description, tags=tags)
-                        log("SUCCESS", "Rolled out IOC to report", selected_report)
-                    elif removal:
-                        report.delete()
-                        log("WARNING", "The report was deleted alongside the rule", selected_report)
-                else:
-                    if deployment_action:
-                        report.remove_iocs_by_id(uuid)
-                        report.append_iocs([ioc])
-                        tags.extend(t for t in report.tags if t not in tags)
-                        if severity > report.severity:
-                            report.update(description=description, tags=tags, severity=severity)
-                            log("INFO", "Upgraded severity for this report to align with MDR", str(severity))
-                        else:
-                            report.update(description=description, tags=tags)
-                        log("SUCCESS", "Deployed IOC to report", selected_report)
-                    elif removal:
-                        if len(report.iocs_) > 1:
-                            report.remove_iocs_by_id(uuid)
-                            report.update()
-                            log("SUCCESS", "Deleted IOC from report", selected_report)
-                        else:
-                            report.delete()
-                            log(
-                                "WARNING",
-                                "The specified report was automatically "
-                                "deleted as there were no other rules",
-                                selected_report,
-                            )
+        if report:
+            if selected_report == name:
+                if deployment_action:
+                    report.remove_iocs_by_id(str(uuid))
+                    report.append_iocs([ioc])
+                    if severity != report.severity:
+                        report.update(description=description, tags=tags, severity=severity)
+                        log("INFO", "Upgraded severity for this report to align with MDR", str(severity))
+                    else:
+                        report.update(description=description, tags=tags)
+                    log("SUCCESS", "Rolled out IOC to report", selected_report)
+                elif removal:
+                    report.delete()
+                    log("WARNING", "The report was deleted alongside the rule", selected_report)
             else:
                 if deployment_action:
-                    report_builder = Report.create(service, selected_report, description, severity)
-                    report_builder.add_ioc(ioc)
-                    for tag in tags:
-                        report_builder.add_tag(tag.strip())
-                    report = report_builder.build()
-                    report.save_watchlist()
-                    watchlist.add_reports([report])  # type: ignore
-                    log("SUCCESS", "Created report and deployed IOC", selected_report)
+                    report.remove_iocs_by_id(uuid)
+                    report.append_iocs([ioc])
+                    tags.extend(t for t in report.tags if t not in tags)
+                    if severity > report.severity:
+                        report.update(description=description, tags=tags, severity=severity)
+                        log("INFO", "Upgraded severity for this report to align with MDR", str(severity))
+                    else:
+                        report.update(description=description, tags=tags)
+                    log("SUCCESS", "Deployed IOC to report", selected_report)
                 elif removal:
-                    log("SKIP", "No report to delete, already removed from system", selected_report)
+                    if len(report.iocs_) > 1:
+                        report.remove_iocs_by_id(uuid)
+                        report.update()
+                        log("SUCCESS", "Deleted IOC from report", selected_report)
+                    else:
+                        report.delete()
+                        log(
+                            "WARNING",
+                            "The specified report was automatically "
+                            "deleted as there were no other rules",
+                            selected_report,
+                        )
+        else:
+            if deployment_action:
+                report_builder = Report.create(service, selected_report, description, severity)
+                report_builder.add_ioc(ioc)
+                for tag in tags:
+                    report_builder.add_tag(tag.strip())
+                report = report_builder.build()
+                report.save_watchlist()
+                watchlist.add_reports([report])  # type: ignore
+                log("SUCCESS", "Created report and deployed IOC", selected_report)
+            elif removal:
+                log("SKIP", "No report to delete, already removed from system", selected_report)
 
         return True
 
@@ -407,8 +375,7 @@ class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
         self.configure_proxy()
 
         if mdr_deployment is not None:
-            # MDRv4 typed deployment path
-            # Normalise string UUIDs to typed MDR objects (orchestrator passes UUIDs)
+            # MDRv4 typed deployment path — aligned with TideDeployment contract
             loaded_mdr = []
             for mdr in mdr_deployment:
                 if type(mdr) is str:
@@ -421,11 +388,20 @@ class CarbonBlackCloudDeploy(CarbonBlackCloudEngineInit, DeployMDR):
                 log("SKIP", "No MDRs to deploy for Carbon Black Cloud")
                 return
 
-            for mdr in mdr_deployment:
-                if mdr.configurations.carbon_black_cloud and hasattr(mdr.configurations.carbon_black_cloud, "query"):
-                    self.deploy_mdr_v4(mdr)
-                else:
-                    log("SKIP", "🛑 Skipping as does not contain a typed CBC rule", mdr.name)
+            deployment_resolution = TideDeployment(
+                deployment=mdr_deployment,
+                system=DetectionSystems.CARBON_BLACK_CLOUD,
+                strategy=deployment_plan)
+
+            for tenant_deployment in deployment_resolution.rule_deployment:  # type: ignore
+                tenant_deployment: TenantDeployment.CarbonBlackCloud
+                log("ONGOING", "Currently targeting tenant", tenant_deployment.tenant.name)
+                cbc_service = CarbonBlackCloudService(tenant_deployment.tenant)
+                for mdr in tenant_deployment.rules:
+                    log("ONGOING", "Processing rule", mdr.name, mdr.metadata.uuid)
+                    self.deploy_mdr_v4(data=mdr,
+                                       service=cbc_service.service,
+                                       tenant_config=tenant_deployment.tenant)
 
         else:
             # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy MDRv3 deployment path

--- a/Engines/modules/carbon_black_cloud.py
+++ b/Engines/modules/carbon_black_cloud.py
@@ -13,7 +13,8 @@ from Engines.modules.deployment import Proxy
 
 class CarbonBlackCloudEngineInit(ABC):
     """
-    Utility class used to initialize all constant relevant to operations with Carbon Black Cloud 
+    Utility class used to initialise all constants relevant to operations with Carbon Black Cloud.
+    Supports both MDRv4 typed format (tenants) and legacy format (setup/secrets).
     """
 
     def __init__(self):
@@ -24,56 +25,6 @@ class CarbonBlackCloudEngineInit(ABC):
 
         CBC_CONFIG = DataTide.Configurations.Systems.CarbonBlackCloud
 
-        CBC_SETUP = HelperTide.fetch_config_envvar(CBC_CONFIG.setup)
-        self.DEFAULT_WATCHLIST = CBC_SETUP["watchlist"]
-        self.CBC_URL = CBC_SETUP["url"]
-        self.SSL_ENABLED = CBC_SETUP["ssl"]
-
-        if self.DEBUG:
-            self.SSL_ENABLED = DebugEnvironment.SSL_ENABLED
-
-        log("INFO", "SSL has been set to",
-        str(self.SSL_ENABLED),
-        "This can be adjusted in carbon_black_cloud.toml with the setup.ssl keyword")
-
-        secrets = {}
-        
-        #Allows to print all errors for all tenants at once and raise Exception later
-        cbc_secrets_error_flag = False 
-        for org in CBC_CONFIG.secrets:
-            tenant_secrets = HelperTide.fetch_config_envvar(CBC_CONFIG.secrets[org])
-            if "org_key" not in tenant_secrets:
-                log(
-                    "FATAL",
-                    "Could not fetch Organization Key for organization",
-                    org,
-                    "Double check that there is a namespaced entry for this organization in the TOML config",
-                )
-                cbc_secrets_error_flag = True
-            if "token" not in tenant_secrets:
-                log(
-                    "FATAL",
-                    "Target organization is not present in Secrets configuration",
-                    org,
-                    "Double check that there is a namespaced entry for this organization in the TOML config",
-                )
-                cbc_secrets_error_flag = True
-
-            #We can skip in case of error as we raise Exception later
-            if not cbc_secrets_error_flag: 
-                secrets[org] = {}
-                secrets[org]["org_key"] = tenant_secrets["org_key"] #type: ignore
-                secrets[org]["token"] = tenant_secrets["token"] #type: ignore
-
-        if cbc_secrets_error_flag:
-            log("FATAL",
-                "The secrets configuration was not setup correctly",
-                "Review the previous errors to understand what attribute was missing")
-            raise KeyError
-        
-        self.CBC_SECRETS = secrets
-        self.ORGANIZATIONS = CBC_SETUP["organizations"]
-        self.VALIDATION_ORGANIZATION = CBC_CONFIG.validation["organization"]
         self.SEVERITY_MAPPING = {
             "Informational": 1,
             "Low": 3,
@@ -82,7 +33,85 @@ class CarbonBlackCloudEngineInit(ABC):
             "Critical": 10,
         }
 
+        # MDRv4 typed format — tenants configured via [platform]/[[tenants]]
+        if CBC_CONFIG.tenants:
+            self._init_from_tenants(CBC_CONFIG)
+        else:
+            # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy format
+            self._init_from_legacy(CBC_CONFIG)
+
+        if self.DEBUG:
+            self.SSL_ENABLED = DebugEnvironment.SSL_ENABLED
+
+        log("INFO", "SSL has been set to",
+        str(self.SSL_ENABLED),
+        "This can be adjusted in carbon_black_cloud.toml with the setup.ssl keyword")
+
+    def _init_from_tenants(self, cbc_config):
+        """Initialise from MDRv4 typed tenant configuration."""
+        first_tenant = cbc_config.tenants[0]
+        self.DEFAULT_WATCHLIST = first_tenant.setup.watchlist or ""
+        self.CBC_URL = first_tenant.setup.url
+        self.SSL_ENABLED = first_tenant.setup.ssl
+        self.PROXY_ENABLED = first_tenant.setup.proxy
+
+        secrets = {}
+        organizations = []
+        for tenant in cbc_config.tenants:
+            org_name = tenant.name
+            organizations.append(org_name)
+            secrets[org_name] = {
+                "org_key": tenant.setup.org_key,
+                "token": tenant.setup.token,
+            }
+
+        self.CBC_SECRETS = secrets
+        self.ORGANIZATIONS = first_tenant.setup.organizations if first_tenant.setup.organizations else organizations
+        self.VALIDATION_ORGANIZATION = organizations[0] if organizations else ""
+
+    def _init_from_legacy(self, cbc_config):
+        """Initialise from legacy setup/secrets configuration."""
+        CBC_SETUP = HelperTide.fetch_config_envvar(cbc_config.setup)
+        self.DEFAULT_WATCHLIST = CBC_SETUP["watchlist"]
+        self.CBC_URL = CBC_SETUP["url"]
+        self.SSL_ENABLED = CBC_SETUP["ssl"]
         self.PROXY_ENABLED = CBC_SETUP["proxy"]
+
+        secrets = {}
+        cbc_secrets_error_flag = False
+        for org in cbc_config.secrets:
+            tenant_secrets = HelperTide.fetch_config_envvar(cbc_config.secrets[org])
+            if "org_key" not in tenant_secrets:
+                log(
+                    "FATAL",
+                    "Could not fetch Organisation Key for organisation",
+                    org,
+                    "Double check that there is a namespaced entry for this organisation in the TOML config",
+                )
+                cbc_secrets_error_flag = True
+            if "token" not in tenant_secrets:
+                log(
+                    "FATAL",
+                    "Target organisation is not present in Secrets configuration",
+                    org,
+                    "Double check that there is a namespaced entry for this organisation in the TOML config",
+                )
+                cbc_secrets_error_flag = True
+
+            if not cbc_secrets_error_flag:
+                secrets[org] = {}
+                secrets[org]["org_key"] = tenant_secrets["org_key"]  # type: ignore
+                secrets[org]["token"] = tenant_secrets["token"]  # type: ignore
+
+        if cbc_secrets_error_flag:
+            log("FATAL",
+                "The secrets configuration was not set up correctly",
+                "Review the previous errors to understand what attribute was missing")
+            raise KeyError
+
+        self.CBC_SECRETS = secrets
+        self.ORGANIZATIONS = CBC_SETUP["organizations"]
+        self.VALIDATION_ORGANIZATION = cbc_config.validation.get("organization", "")
 
     def configure_proxy(self):
         """Applies the proxy configuration for this system.

--- a/Engines/modules/deployment.py
+++ b/Engines/modules/deployment.py
@@ -662,8 +662,8 @@ class TideDeployment:
         match system:
             case DetectionSystems.SPLUNK:
                 return DataTide.Configurations.Systems.Splunk
-            # case DetectionSystems.CARBON_BLACK_CLOUD:
-            #    return DataTide.Configurations.Systems.CarbonBlackCloud
+            case DetectionSystems.CARBON_BLACK_CLOUD:
+                return DataTide.Configurations.Systems.CarbonBlackCloud
             case DetectionSystems.SENTINEL:
                 return DataTide.Configurations.Systems.Sentinel
             case DetectionSystems.DEFENDER_FOR_ENDPOINT:
@@ -693,6 +693,8 @@ class TideDeployment:
                 mdr_config = data.configurations.harfanglab
             case DetectionSystems.SPLUNK:
                 mdr_config = data.configurations.splunk
+            case DetectionSystems.CARBON_BLACK_CLOUD:
+                mdr_config = data.configurations.carbon_black_cloud
             case _:
                 log(
                     "FATAL",

--- a/Engines/modules/models.py
+++ b/Engines/modules/models.py
@@ -203,7 +203,21 @@ class TideConfigs:
 
         @dataclass
         class CarbonBlackCloud(SystemConfig):
-            ...
+
+            @dataclass
+            class Tenant(SystemConfig.Tenant):
+
+                @dataclass
+                class Setup(SystemConfig.Tenant.Setup):
+                    url: str
+                    org_key: str
+                    token: str
+                    watchlist: Optional[str] = None
+                    organizations: Optional[Sequence[str]] = None
+
+                setup: Setup
+
+            tenants: Optional[Sequence[Tenant]]
 
         @dataclass
         class SentinelOne(SystemConfig):
@@ -680,7 +694,12 @@ class TideModels:
 
             @dataclass
             class CarbonBlackCloud(TideDefinitionsModels.SystemConfigurationModel):
-                ...
+                query: str
+                organizations: Optional[Sequence[str]] = None
+                watchlist: Optional[str] = None
+                report: Optional[str] = None
+                tags: Optional[Sequence[str]] = None
+                rule_id_bundle: Optional[Mapping[str, str]] = None
 
             @dataclass
             class HarfangLab(TideDefinitionsModels.SystemConfigurationModel):
@@ -739,7 +758,7 @@ class TideModels:
             defender_for_endpoint: Optional[DefenderForEndpoint] = None
             sentinel_one: Optional[SentinelOne] = None
             crowdstrike: Optional[Crowdstrike] = None
-            carbon_black_cloud: Optional[Mapping] = None
+            carbon_black_cloud: Optional[Union[CarbonBlackCloud, Mapping]] = None
             splunk: Optional[Union[Splunk, Mapping]] = None
             harfanglab: Optional[HarfangLab] = None
 
@@ -773,7 +792,7 @@ class TenantDeployment:
 
     @dataclass
     class CarbonBlackCloud(TenantDeploymentModel):
-        tenant: TideConfigs.Systems.DefenderForEndpoint.Tenant
+        tenant: TideConfigs.Systems.CarbonBlackCloud.Tenant
 
     @dataclass
     class SentinelOne(TenantDeploymentModel):

--- a/Engines/modules/systems/carbon_black_cloud.py
+++ b/Engines/modules/systems/carbon_black_cloud.py
@@ -1,0 +1,43 @@
+import git
+import sys
+
+from cbc_sdk.rest_api import CBCloudAPI
+
+sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
+
+from Engines.modules.logs import log
+from Engines.modules.debug import DebugEnvironment
+from Engines.modules.models import TideConfigs
+from Engines.modules.deployment import Proxy
+
+
+class CarbonBlackCloudService:
+    """Interface to connect to a Carbon Black Cloud tenant.
+
+    Initialised on a single tenant basis, following the same architectural
+    pattern as SentinelService, DefenderForEndpointService, etc.
+    """
+
+    def __init__(self, tenant_config: TideConfigs.Systems.CarbonBlackCloud.Tenant) -> None:
+        self.tenant_config = tenant_config
+        self.setup = tenant_config.setup
+
+        if self.setup.proxy:
+            Proxy.set_proxy()
+        else:
+            Proxy.unset_proxy()
+
+        if DebugEnvironment.ENABLED:
+            ssl = DebugEnvironment.SSL_ENABLED
+        else:
+            ssl = self.setup.ssl
+
+        self.service = CBCloudAPI(
+            url=self.setup.url,
+            token=self.setup.token,
+            org_key=self.setup.org_key,
+            ssl_verify=ssl,
+        )
+
+        log("SUCCESS", "Successfully connected to Carbon Black Cloud on tenant",
+            tenant_config.name)

--- a/Engines/modules/tide.py
+++ b/Engines/modules/tide.py
@@ -908,6 +908,48 @@ class SystemLoader:
             advanced=advanced
         )
 
+    @staticmethod
+    def carbon_black_cloud(mdr_config:dict[str, Any])->TideModels.MDR.Configurations.CarbonBlackCloud:
+        """Build a Carbon Black Cloud system configuration object from raw MDR config.
+
+        Transforms the provided mapping into a
+        ``TideModels.MDR.Configurations.CarbonBlackCloud`` instance by
+        extracting the base configuration values, resolving any external rule
+        id bundle, and mapping remaining fields to the typed dataclass.
+
+        Args:
+            mdr_config: A mapping containing Carbon Black Cloud configuration
+                fields as produced by the indexer or TOML loader.
+
+        Returns:
+            A ``TideModels.MDR.Configurations.CarbonBlackCloud`` instance.
+        """
+
+        CarbonBlackCloud = TideModels.MDR.Configurations.CarbonBlackCloud
+
+        mdr_config, base_config = SystemLoader._base_configuration(mdr_config)
+        mdr_config, rule_id_bundle = SystemLoader._external_rule_id(mdr_config)
+
+        query = mdr_config.pop("query")
+        organizations = mdr_config.pop("organizations", None) or mdr_config.pop("organization", None)
+        watchlist = mdr_config.pop("watchlist", None)
+        report = mdr_config.pop("report", None)
+        tags = mdr_config.pop("tags", None)
+
+        return CarbonBlackCloud(
+            schema=base_config.schema,
+            status=base_config.status,
+            contributors=base_config.contributors,
+            tenants=base_config.tenants,
+            flags=base_config.flags,
+            query=query,
+            organizations=organizations,
+            watchlist=watchlist,
+            report=report,
+            tags=tags,
+            rule_id_bundle=rule_id_bundle if rule_id_bundle else None  # type: ignore
+        )        )
+
 
 class ConfigurationsLoader:
     @staticmethod
@@ -1186,6 +1228,13 @@ class TideLoader:
             configurations.harfanglab = SystemLoader.harfanglab(system_configurations.pop("harfanglab"))
         if system_configurations.get("splunk"):
             configurations.splunk = SystemLoader.splunk(system_configurations.pop("splunk"))
+        if system_configurations.get("carbon_black_cloud"):
+            cbc_config = system_configurations.get("carbon_black_cloud")
+            if isinstance(cbc_config, dict) and cbc_config.get("schema", "").startswith("carbon_black_cloud::"):
+                configurations.carbon_black_cloud = SystemLoader.carbon_black_cloud(system_configurations.pop("carbon_black_cloud"))
+            else:
+                # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy dict passthrough
+                configurations.carbon_black_cloud = system_configurations.pop("carbon_black_cloud")
 
         return TideModels.MDR(**mdr,
                                 metadata=metadata,
@@ -1208,6 +1257,9 @@ class TideLoader:
     @overload
     @staticmethod
     def load_platform_config(platform_config:dict, system:Literal[DetectionSystems.SPLUNK])->TideConfigs.Systems.Splunk.Platform: ...
+    @overload
+    @staticmethod
+    def load_platform_config(platform_config:dict, system:Literal[DetectionSystems.CARBON_BLACK_CLOUD])->TideConfigs.Systems.CarbonBlackCloud.Platform: ...
     @overload
     @staticmethod
     def load_platform_config(platform_config:dict, system:Literal[DetectionSystems.HARFANGLAB])->TideConfigs.Systems.HarfangLab.Platform: ...
@@ -1258,6 +1310,9 @@ class TideLoader:
 
             case DetectionSystems.SPLUNK:
                 return TideConfigs.Systems.Splunk.Platform(**platform_config)
+
+            case DetectionSystems.CARBON_BLACK_CLOUD:
+                return SystemConfig.Platform(**platform_config)
 
             case _:
                 return SystemConfig.Platform(**platform_config)
@@ -1367,6 +1422,9 @@ class TideLoader:
 
                 case DetectionSystems.SPLUNK:
                     setup = TideConfigs.Systems.Splunk.Tenant.Setup(**setup_with_secrets)
+
+                case DetectionSystems.CARBON_BLACK_CLOUD:
+                    setup = TideConfigs.Systems.CarbonBlackCloud.Tenant.Setup(**setup_with_secrets)
 
                 case _:
                     raise NotImplementedError(f"Platform {platform.name} is not recognized")
@@ -1613,10 +1671,16 @@ class DataTide:
                 Index = dict(
                     IndexTide.load()["configurations"]["systems"]["carbon_black_cloud"]
                 )
-                tide = dict(Index["tide"])
-                setup = dict(Index["setup"])
-                secrets = dict(Index["secrets"])
-                validation = dict(Index["validation"])
+                # New MDRv4 typed format
+                platform = TideLoader.load_platform_config(dict(Index["platform"]), DetectionSystems.CARBON_BLACK_CLOUD) if "platform" in Index else None
+                modifiers = TideLoader.load_modifiers_config(Index.get("modifiers", [])) if "platform" in Index else None
+                tenants = TideLoader.load_tenants_config(Index["tenants"], DetectionSystems.CARBON_BLACK_CLOUD) if "platform" in Index and "tenants" in Index else None
+
+                # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy format
+                tide = dict(Index.get("tide", {}))
+                setup = dict(Index.get("setup", {}))
+                secrets = dict(Index.get("secrets", {}))
+                validation = dict(Index.get("validation", {}))
 
             @dataclass
             class Sentinel(TideConfigs.Systems.Sentinel):

--- a/Engines/modules/tide.py
+++ b/Engines/modules/tide.py
@@ -948,7 +948,7 @@ class SystemLoader:
             report=report,
             tags=tags,
             rule_id_bundle=rule_id_bundle if rule_id_bundle else None  # type: ignore
-        )        )
+        )
 
 
 class ConfigurationsLoader:

--- a/Engines/validation/carbon_black_cloud_query.py
+++ b/Engines/validation/carbon_black_cloud_query.py
@@ -14,12 +14,27 @@ from Engines.modules.carbon_black_cloud import CarbonBlackCloudEngineInit
 
 class CarbonBlackCloudValidateQuery(CarbonBlackCloudEngineInit, ValidateQuery):
 
-    def check_query(self, mdr:dict, service:CBCloudAPI):
-        query:str = mdr["configurations"]["carbon_black_cloud"].get("query")
-        mdr_uuid = mdr.get('uuid') or mdr["metadata"]["uuid"]
+    def check_query(self, mdr, service:CBCloudAPI):
+        # MDRv4 typed access
+        if hasattr(mdr, "configurations") and hasattr(mdr, "metadata"):
+            config = mdr.configurations.carbon_black_cloud
+            if config and hasattr(config, "query"):
+                query = config.query
+                mdr_uuid = mdr.metadata.uuid
+                mdr_name = mdr.name
+            else:
+                os.environ["VALIDATION_ERROR_RAISED"] = "True"
+                log("FATAL", "Missing CBC configuration in MDR", mdr.name)
+                return
+        else:
+            # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy dict access
+            query = mdr["configurations"]["carbon_black_cloud"].get("query")
+            mdr_uuid = mdr.get('uuid') or mdr["metadata"]["uuid"]
+            mdr_name = mdr.get("name", "unknown")
+
         if not query:
             os.environ["VALIDATION_ERROR_RAISED"] = "True"
-            log("FATAL", "Missing query in MDR", f"{mdr.get('name')} ({mdr_uuid})")
+            log("FATAL", "Missing query in MDR", f"{mdr_name} ({mdr_uuid})")
             return
 
         try:
@@ -28,8 +43,7 @@ class CarbonBlackCloudValidateQuery(CarbonBlackCloudEngineInit, ValidateQuery):
                 log("SUCCESS", "The query is a valid CBC search")
             else:
                 log("FATAL",
-                    f"The CBC query is invalid for : {mdr['name']} ({mdr_uuid})",
-                    # Same error message as displayed on the GUI
+                    f"The CBC query is invalid for : {mdr_name} ({mdr_uuid})",
                     "Ensure a value is included and slashes, colons, and spaces are manually escaped")
         except Exception as error:
             log("FATAL", "Failed to validate the query on the CBC tenant")
@@ -56,24 +70,27 @@ class CarbonBlackCloudValidateQuery(CarbonBlackCloudEngineInit, ValidateQuery):
             self.VALIDATION_ORGANIZATION,
         )
 
-        # Start deployment routine
         for mdr in deployment:
-            mdr_data:dict = DataTide.Models.mdr[mdr]
-            mdr_uuid = mdr_data.get('uuid') or mdr_data["metadata"]["uuid"]
+            mdr_data = DataTide.Models.mdr[mdr]
 
-            # Check if modified MDR contains a platform entry (by safety, but should not happen since
-            # the orchestrator will filter for the platform)
-            if self.DEPLOYER_IDENTIFIER in mdr_data["configurations"].keys():
-                # Connection routine, if not connected yet.
-                log("ONGOING",
-                    "Validating CBC Lucene Query",
-                    f"{mdr_data['name']} ({mdr_uuid}")
-                self.check_query(mdr_data, service)
+            # Handle both typed MDR objects and legacy dicts
+            if hasattr(mdr_data, "configurations"):
+                # MDRv4 typed object
+                if mdr_data.configurations.carbon_black_cloud:
+                    log("ONGOING", "Validating CBC Lucene Query",
+                        f"{mdr_data.name} ({mdr_data.metadata.uuid})")
+                    self.check_query(mdr_data, service)
+                else:
+                    log("SKIP", f"🛑 Skipping {mdr_data.name} as does not contain a CBC configuration section")
             else:
-                log(
-                    "SKIP",
-                    f"🛑 Skipping {mdr_data.get('name')} as does not contain a Splunk configuration section",
-                )
+                # TODO: DEPRECATED [carbon-black-cloud-mdrv4] — Legacy dict access
+                mdr_uuid = mdr_data.get('uuid') or mdr_data["metadata"]["uuid"]
+                if self.DEPLOYER_IDENTIFIER in mdr_data["configurations"].keys():
+                    log("ONGOING", "Validating CBC Lucene Query",
+                        f"{mdr_data['name']} ({mdr_uuid})")
+                    self.check_query(mdr_data, service)
+                else:
+                    log("SKIP", f"🛑 Skipping {mdr_data.get('name')} as does not contain a CBC configuration section")
 
 
 def declare():


### PR DESCRIPTION
## Summary

Migrates the Carbon Black Cloud (CBC) deployer from MDRv3 (dict-based configuration access) to MDRv4 (typed Python dataclass framework) with full backwards compatibility. CBC was the **last remaining MDRv3 system** — this brings full framework consistency across all 7 detection platforms.

Follows the exact migration pattern established by the Splunk MDRv4 migration (PR #53).

## Changes

### `Engines/modules/models.py`
- Populated `TideConfigs.Systems.CarbonBlackCloud` with typed `Tenant` → `Setup` hierarchy (`url`, `ssl`, `org_key`, `token`, `watchlist`, `organizations`)
- Populated `TideModels.MDR.Configurations.CarbonBlackCloud` with typed fields (`query`, `organizations`, `watchlist`, `report`, `tags`, `rule_id_bundle`)
- Changed MDR config field from `Optional[Mapping]` to `Optional[Union[CarbonBlackCloud, Mapping]]`
- **Bugfix**: Fixed `TenantDeployment.CarbonBlackCloud` — was incorrectly referencing `DefenderForEndpoint.Tenant`

### `Engines/modules/tide.py`
- Added `SystemLoader.carbon_black_cloud()` static method for typed MDR parsing
- Added CBC routing in `TideLoader.load_mdr()` with schema version gating (`carbon_black_cloud::` prefix)
- Added CBC cases in `load_platform_config()` (overload + match case) and `load_tenants_config()`
- Updated `DataTide.Configurations.Systems.CarbonBlackCloud` to dual-format: typed attributes when `[platform]` exists, legacy dict attributes always available

### `Engines/modules/deployment.py`
- Uncommented `system_configuration_resolver` CBC case
- Added `mdr_configuration_resolver` CBC case

### `Configurations/systems/carbon_black_cloud.toml`
- Added new `[platform]`/`[[tenants]]`/`[[modifiers]]` format
- Preserved legacy `[tide]`/`[setup]`/`[secrets]` format for backwards compatibility

### `Engines/deployment/carbon_black_cloud.py`
- Added `deploy_mdr_v4()` method using typed attribute access
- Updated `deploy()` with dual MDRv3/v4 signature (`deployment` + `mdr_deployment`/`deployment_plan`)

### `Engines/modules/carbon_black_cloud.py`
- Refactored init into `_init_from_tenants()` (MDRv4) and `_init_from_legacy()` (MDRv3)
- Automatic format detection based on presence of `tenants` in config

### `Engines/validation/carbon_black_cloud_query.py`
- Added v4 typed query extraction path alongside legacy dict access
- Fixed log message that incorrectly referenced "Splunk" instead of "CBC"

## Backwards Compatibility

- Existing MDRv3 CBC deployments continue to work via legacy dict code paths
- New MDRv4 schema objects deploy via typed path when schema declares `carbon_black_cloud::` version
- TOML config supports both legacy and new format simultaneously
- All legacy code paths marked with `# TODO: DEPRECATED [carbon-black-cloud-mdrv4]` breadcrumbs

## Testing

- [ ] Verify legacy MDRv3 dict-based deployments still work
- [ ] Verify new MDRv4 typed deployments work with `carbon_black_cloud::3.0` schema
- [ ] Verify dual TOML format loading
- [ ] Verify query validation with both typed and dict MDRs

## Related

- Closes #57
- Pattern reference: PR #53 (Splunk MDRv4 migration)
- Spec reference: Issue #52 (MDRv4 framework migration)