### PR TITLE
fix(gitlab): enable FF_USE_NEW_BASH_EVAL_STRATEGY for gitlab ci templates

### DIFF
--- a/Pipelines/Gitlab/modules/documentation.yml
+++ b/Pipelines/Gitlab/modules/documentation.yml
@@ -41,6 +41,8 @@
     - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   needs:
     - 🔮 Validation Toolchain
+  variables:
+    FF_USE_NEW_BASH_EVAL_STRATEGY: "true"
   resource_group: wiki
 
 🚧 MDR Staging Documentation:

--- a/Pipelines/Gitlab/modules/framework.yml
+++ b/Pipelines/Gitlab/modules/framework.yml
@@ -17,5 +17,7 @@
     - if:  $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   needs:
     - 🔮 Validation Toolchain
+  variables:
+    FF_USE_NEW_BASH_EVAL_STRATEGY: "true"
   resource_group: synthesis
 

--- a/Pipelines/Gitlab/modules/mutation.yml
+++ b/Pipelines/Gitlab/modules/mutation.yml
@@ -14,4 +14,6 @@
   - fi
   rules:
     - if:  $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
+  variables:
+    FF_USE_NEW_BASH_EVAL_STRATEGY: "true"
   resource_group: mutation


### PR DESCRIPTION
Several pipeline modules use multi-line `if/then/fi` blocks split across separate YAML `script:` entries.   

Without `FF_USE_NEW_BASH_EVAL_STRATEGY: "true"`, GitLab CI executes each `- line` as an independent shell command, so the `then` branch runs unconditionally.  

## Affected modules

### modules/documentation.yml (Documentation Toolchain)

- https://github.com/OpenTideHQ/CoreTide/blob/0cb3fc913bab12e0ffbb783a83ec20ab75410acd/Pipelines/Gitlab/modules/documentation.yml#L19-L21
- https://github.com/OpenTideHQ/CoreTide/blob/0cb3fc913bab12e0ffbb783a83ec20ab75410acd/Pipelines/Gitlab/modules/documentation.yml#L31-L35

__Fails:__ `cp: cannot stat 'staging_index.json'` - runs even when file doesn't exist.

### modules/framework.yml (Framework Generation Toolchain)

- https://github.com/OpenTideHQ/CoreTide/blob/0cb3fc913bab12e0ffbb783a83ec20ab75410acd/Pipelines/Gitlab/modules/framework.yml#L11-L15

__Fails:__ `git commit runs unconditionally` -> `fatal: empty ident name`

### modules/mutation.yml (Data Mutation Toolchain)

- https://github.com/OpenTideHQ/CoreTide/blob/0cb3fc913bab12e0ffbb783a83ec20ab75410acd/Pipelines/Gitlab/modules/mutation.yml#L10-L14

-----

## Suggested fix

> Note: MDR Staging Documentation in the same file already has `FF_USE_NEW_BASH_EVAL_STRATEGY: "true"`, but the main job doesn't.

Add `FF_USE_NEW_BASH_EVAL_STRATEGY: "true"` to all affected jobs (already used in validation and some deployment jobs), or collapse to single-line: `if [ -e file ]; then cp file ./; fi`



fixes #72 