### PR TITLE
Improve Defender XDR query column validation

### DIFF
--- a/Engines/validation/defender_for_endpoint_query.py
+++ b/Engines/validation/defender_for_endpoint_query.py
@@ -23,6 +23,7 @@ from Engines.modules.systems.defender_for_endpoint import DefenderForEndpointSer
 # and ReportId, but other Defender XDR tables such as Email*, Identity*, and
 # CloudAppEvents do not require DeviceId.
 TIMESTAMP_COLUMNS = {"Timestamp", "TimeGenerated"}
+DEFENDER_XDR_TIMESTAMP_COLUMNS = {"Timestamp"}
 REPORT_ID_COLUMNS = {"ReportId"}
 DEVICE_ID_COLUMNS = {"DeviceId"}
 OBSERVATION_ID_COLUMNS = {"ObservationId"}
@@ -125,7 +126,7 @@ def required_column_groups(query:str)->list[set[str]]:
         for table in tables
     }
 
-    groups = [TIMESTAMP_COLUMNS]
+    groups = [DEFENDER_XDR_TIMESTAMP_COLUMNS if categories else TIMESTAMP_COLUMNS]
 
     if "endpoint" in categories:
         groups.extend([DEVICE_ID_COLUMNS, REPORT_ID_COLUMNS])

--- a/Engines/validation/defender_for_endpoint_query.py
+++ b/Engines/validation/defender_for_endpoint_query.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import git
 
@@ -15,9 +16,144 @@ from Engines.modules.models import (TideModels,
 from Engines.modules.deployment import TideDeployment
 from Engines.modules.systems.defender_for_endpoint import DefenderForEndpointService
 
-# Per Microsoft documentation for MDE custom detection rules:
+# Per Microsoft documentation for Defender XDR custom detection rules:
 # https://learn.microsoft.com/en-us/defender-xdr/custom-detection-rules
-MDE_REQUIRED_COLUMNS = {"Timestamp", "DeviceId", "ReportId"}
+# Required event identity columns differ by the Defender product tables referenced
+# in the query. Microsoft Defender for Endpoint Device* tables require DeviceId
+# and ReportId, but other Defender XDR tables such as Email*, Identity*, and
+# CloudAppEvents do not require DeviceId.
+TIMESTAMP_COLUMNS = {"Timestamp", "TimeGenerated"}
+REPORT_ID_COLUMNS = {"ReportId"}
+DEVICE_ID_COLUMNS = {"DeviceId"}
+OBSERVATION_ID_COLUMNS = {"ObservationId"}
+IMPACTED_ASSET_IDENTIFIER_COLUMNS = {
+    "DeviceId",
+    "DeviceName",
+    "RemoteDeviceName",
+    "RecipientEmailAddress",
+    "SenderFromAddress",
+    "SenderMailFromAddress",
+    "SenderObjectId",
+    "RecipientObjectId",
+    "AccountObjectId",
+    "AccountSid",
+    "AccountUpn",
+    "InitiatingProcessAccountSid",
+    "InitiatingProcessAccountUpn",
+    "InitiatingProcessAccountObjectId",
+}
+
+DEFENDER_XDR_TABLES = {
+    # Microsoft Defender for Endpoint tables.
+    "DeviceEvents": "endpoint",
+    "DeviceFileCertificateInfo": "endpoint",
+    "DeviceFileEvents": "endpoint",
+    "DeviceImageLoadEvents": "endpoint",
+    "DeviceInfo": "endpoint",
+    "DeviceLogonEvents": "endpoint",
+    "DeviceNetworkEvents": "endpoint",
+    "DeviceNetworkInfo": "endpoint",
+    "DeviceProcessEvents": "endpoint",
+    "DeviceRegistryEvents": "endpoint",
+
+    # Alert tables.
+    "AlertEvidence": "alert",
+    "AlertInfo": "alert",
+
+    # Microsoft Defender for Office 365 tables.
+    "CampaignInfo": "xdr",
+    "EmailAttachmentInfo": "xdr",
+    "EmailEvents": "xdr",
+    "EmailPostDeliveryEvents": "xdr",
+    "EmailUrlInfo": "xdr",
+    "FileMaliciousContentInfo": "xdr",
+    "MessageEvents": "xdr",
+    "MessagePostDeliveryEvents": "xdr",
+    "MessageUrlInfo": "xdr",
+    "UrlClickEvents": "xdr",
+
+    # Microsoft Defender for Cloud Apps and identity tables.
+    "AADSignInEventsBeta": "xdr",
+    "AADSpnSignInEventsBeta": "xdr",
+    "CloudAppEvents": "xdr",
+    "EntraIdSignInEvents": "xdr",
+    "EntraIdSpnSignInEvents": "xdr",
+    "IdentityAccountInfo": "xdr",
+    "IdentityDirectoryEvents": "xdr",
+    "IdentityInfo": "xdr",
+    "IdentityLogonEvents": "xdr",
+    "IdentityQueryEvents": "xdr",
+    "OAuthAppInfo": "xdr",
+}
+
+def strip_kql_literals_and_comments(query:str)->str:
+    """
+    Removes KQL comments and string literals before scanning table names.
+    This avoids matching table names mentioned in comments or text constants.
+    """
+    query = re.sub(r"/\*.*?\*/", " ", query, flags=re.DOTALL)
+    query = re.sub(r"//.*", " ", query)
+    query = re.sub(r"@?'(?:''|[^'])*'", " ", query)
+    query = re.sub(r'@?"(?:""|[^"])*"', " ", query)
+    return query
+
+def defender_xdr_tables_in_query(query:str)->set[str]:
+    """
+    Returns known Defender XDR advanced hunting tables referenced by a query.
+    """
+    query = strip_kql_literals_and_comments(query)
+    tables = set()
+    for table in DEFENDER_XDR_TABLES:
+        if re.search(rf"(?<![\w.]){re.escape(table)}(?!\w)", query):
+            tables.add(table)
+    tables.update(
+        table
+        for table in re.findall(r"(?<![\w.])(Observation\w+)(?!\w)", query)
+        if table != "ObservationId"
+    )
+    return tables
+
+def required_column_groups(query:str)->list[set[str]]:
+    """
+    Builds accepted column groups for Defender XDR custom detection output.
+    Each returned set is an OR group: at least one column in each group must be
+    present in the returned schema.
+    """
+    tables = defender_xdr_tables_in_query(query)
+    categories = {
+        "observation" if table.startswith("Observation") else DEFENDER_XDR_TABLES[table]
+        for table in tables
+    }
+
+    groups = [TIMESTAMP_COLUMNS]
+
+    if "endpoint" in categories:
+        groups.extend([DEVICE_ID_COLUMNS, REPORT_ID_COLUMNS])
+    if "observation" in categories:
+        groups.append(OBSERVATION_ID_COLUMNS)
+    if "xdr" in categories or not categories:
+        if REPORT_ID_COLUMNS not in groups:
+            groups.append(REPORT_ID_COLUMNS)
+    if "endpoint" not in categories:
+        groups.append(IMPACTED_ASSET_IDENTIFIER_COLUMNS)
+
+    return groups
+
+def missing_required_column_groups(query:str, returned_columns:set[str])->list[str]:
+    missing = []
+    for group in required_column_groups(query):
+        if returned_columns.isdisjoint(group):
+            missing.append(" or ".join(sorted(group)))
+    return missing
+
+def returned_schema_columns(response:dict)->set[str]:
+    # Graph API returns lowercase keys ("name"), XDR API uses PascalCase ("Name")
+    returned_columns = {
+        col.get("name") or col.get("Name")
+        for col in response.get("schema", response.get("Schema", []))
+    }
+    returned_columns.discard(None)
+    return returned_columns
 
 class DefenderForEndpointValidateQuery(ValidateQuery):
 
@@ -39,20 +175,17 @@ class DefenderForEndpointValidateQuery(ValidateQuery):
             os.environ["VALIDATION_ERROR_RAISED"] = "True"
             return
 
-        # Step 2 — Check the returned schema for required columns
-        # Graph API returns lowercase keys ("name"), XDR API uses PascalCase ("Name")
-        returned_columns = {
-            col.get("name") or col.get("Name")
-            for col in response.get("schema", response.get("Schema", []))
-        }
-        returned_columns.discard(None)
-        missing = MDE_REQUIRED_COLUMNS - returned_columns
+        # Step 2 — Check the returned schema for product-aware required columns
+        returned_columns = returned_schema_columns(response)
+        missing = missing_required_column_groups(query, returned_columns)
         if missing:
             log("FATAL",
-                f"MDE custom detection query is missing required columns: {', '.join(sorted(missing))}",
+                f"Defender XDR custom detection query is missing required columns: {', '.join(missing)}",
                 f"{mdr_name} ({mdr_uuid})",
-                "Per Microsoft documentation, MDE custom detection queries must include "
-                "Timestamp, DeviceId, and ReportId columns in the output. "
+                f"Detected Defender XDR tables: {', '.join(sorted(defender_xdr_tables_in_query(query))) or 'none'}",
+                "Per Microsoft documentation, Defender XDR custom detection queries must include "
+                "Timestamp or TimeGenerated, event identity columns for the queried table family, "
+                "and a supported impacted asset identifier in the output. "
                 "See: https://learn.microsoft.com/en-us/defender-xdr/custom-detection-rules")
             os.environ["VALIDATION_ERROR_RAISED"] = "True"
 


### PR DESCRIPTION
Fixes #76.

## Summary

- Replaces the MDE-only `Timestamp`/`DeviceId`/`ReportId` validation with table-aware Defender XDR requirements.
- Adds a local Defender XDR table map to distinguish Endpoint `Device*`, `Alert*`, `Observation*`, and other Defender product tables.
- Validates returned query schema with OR-groups for required event identity columns and supported impacted asset identifiers.
- Requires the raw `Timestamp` column for detected Defender XDR tables, matching Microsoft’s event identity requirements; `TimeGenerated` remains accepted only for the fallback/no-known-XDR-table case.
- Strips KQL comments and string literals before scanning table names to avoid false table matches.

## Validation

- `python -m py_compile Engines/validation/defender_for_endpoint_query.py`
- Static helper tests for Endpoint, Email, Identity, Cloud App, Alert, Observation, mixed table-family queries, KQL table scanning edge cases, and adversarial `TimeGenerated` cases for Defender XDR tables.

## Note

The CoreTide repository does not expose an `origin/main` branch; this PR targets `development`, the repository default branch.