### PR TITLE
Fix Sentinel dynamic alert overrides

### DIFF
--- a/Engines/deployment/sentinel.py
+++ b/Engines/deployment/sentinel.py
@@ -94,12 +94,20 @@ class SentinelDeploy(DeployMDR):
         if dynamic_properties:=configuration.alert.dynamic_properties:
             alert_dynamic_properties = []
             for property in dynamic_properties:
+                if property.property == "Tactics":
+                    details_overrides.alert_tactics_column_name = property.column
+                    continue
+                if property.property == "Severity":
+                    details_overrides.alert_severity_column_name = property.column
+                    continue
+
                 alert_dynamic_property = service.alert_rules.models.AlertPropertyMapping()
                 alert_dynamic_property.alert_property = property.property
                 alert_dynamic_property.value = property.column
                 alert_dynamic_properties.append(alert_dynamic_property)
 
-            details_overrides.alert_dynamic_properties = alert_dynamic_properties
+            if alert_dynamic_properties:
+                details_overrides.alert_dynamic_properties = alert_dynamic_properties
 
         rule.alert_details_override = details_overrides
 

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Microsoft Sentinel.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Microsoft Sentinel.yaml
@@ -327,7 +327,7 @@ properties:
         title: Alert Dynamic Properties
         icon: 💽
         type: array
-        description: Override alert default properties, select an alert property from the Alert property drop-down list.
+        description: Override alert default properties, select an alert property from the Alert property drop-down list. Tactics and Severity are routed to their dedicated Sentinel alert override fields.
         tide.mdr.parameter: alertDetailsOverride.alertDynamicProperties
         items:
           type: object


### PR DESCRIPTION
## Summary

- Routes Sentinel `dynamic_properties` entries for `Tactics` and `Severity` to the dedicated `AlertDetailsOverride` fields (`alert_tactics_column_name` and `alert_severity_column_name`) instead of sending them as `alertDynamicProperties` mappings.
- Keeps valid `AlertPropertyMapping` values such as `ProductName` and `Techniques` in `alert_dynamic_properties`.
- Avoids assigning an empty dynamic property list when only tactics/severity override columns are configured.
- Documents the special routing in the Sentinel MDR subsystem schema description.

## Why

The Sentinel API rejects `alertDynamicProperties[].alertProperty = "Tactics"` with `Field alertProperty contains an invalid value 'Tactics'`. Microsoft documents `Tactics` and `Severity` as dedicated alert details override columns, not members of the `AlertProperty` enum.

## Validation

- Static deployment regression with fake Sentinel SDK model classes verifying:
  - `Tactics` maps to `alert_tactics_column_name`
  - `Severity` maps to `alert_severity_column_name`
  - valid dynamic properties remain under `alert_dynamic_properties`
  - each dynamic property mapping is a unique object
- `python -m py_compile Engines/deployment/sentinel.py`
- IDE diagnostics report no errors for changed files.