### PR TITLE
fix: actor identifier stripping, wiki perf, and Alert Responders delegation

### DIFF
--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -177,8 +177,10 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                 actors = model_value_doc(entry, "actors") or []
                 for actor in actors:
                     if type(actor) is dict:
-                        actor_name = get_vocab_entry("actors", actor.get("name", "").split("::")[1], "name")
-                        actor_aliases = get_vocab_entry("actors", actor.get("name", "").split("::")[1], "alias")
+                        raw_id = actor.get("name", "").split("::")[1]
+                        clean_id = raw_id.split(" #")[0].strip()
+                        actor_name = get_vocab_entry("actors", clean_id, "name")
+                        actor_aliases = get_vocab_entry("actors", clean_id, "alias")
                         if actor_aliases:
                             actor_aliases = list(set(actor_aliases))
                             actor_name += ", " + ", ".join(actor_aliases)

--- a/Engines/documentation/wiki_navigation.py
+++ b/Engines/documentation/wiki_navigation.py
@@ -144,14 +144,14 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
 
 
             if value == "name":
-                object_backlink = str(backlink_resolver(str(model_value_doc(entry, "uuid"))))
+                object_backlink = str(backlink_resolver(str(model_value_doc(entry, "uuid")), hover=False))
                 object_backlink = object_backlink.replace("../", "./")
                 row[value] = object_backlink
 
             elif value == "att&ck":
                 techniques = techniques_resolver(entry)
                 if techniques:
-                    techniques = rich_attack_links(techniques)
+                    techniques = rich_attack_links(techniques, hover=False)
                     if model_type == "mdr":
                         value = mdr_attack_technique
                     row[value] = techniques
@@ -196,7 +196,7 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                     vectors = [vectors] if type(vectors) is str else vectors
                     vectors_links = []
                     for vector in vectors:
-                        object_backlink = str(backlink_resolver(str(vector)))
+                        object_backlink = str(backlink_resolver(str(vector), hover=False))
                         object_backlink = object_backlink.replace("../", "./")
                         vectors_links.append(object_backlink)
                     row[value] = ", ".join(vectors_links)
@@ -209,7 +209,7 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                     vectors = [vectors] if type(vectors) is str else vectors
                     vectors_links = []
                     for vector in vectors:
-                        object_backlink = str(backlink_resolver(str(vector)))
+                        object_backlink = str(backlink_resolver(str(vector), hover=False))
                         object_backlink = object_backlink.replace("../", "./")
                         vectors_links.append(object_backlink)
                     row[value] = ", ".join(vectors_links)
@@ -256,7 +256,7 @@ def build_search(model_type, mdr_status:Optional[Literal["ACTIVE", "DEPRECATED"]
                 elif value == "detection_model":
                     model_value = model_value_doc(entry, "detection_model")
                     if model_value:
-                        object_backlink = str(backlink_resolver(str(model_value)))
+                        object_backlink = str(backlink_resolver(str(model_value), hover=False))
                         object_backlink = object_backlink.replace("../", "./")
                         row[value] = object_backlink
                     else:

--- a/Engines/export/table_export.py
+++ b/Engines/export/table_export.py
@@ -64,8 +64,10 @@ class TableExporter:
     def _flatten_actors(self, actors:list[dict])->list:
        
         def _enrich_actor_name(actor:str)->str:
-            actor_data:dict = get_vocab_entry("actors", actor.split("::")[1]) #type: ignore
-            return str(actor_data.get("name"))
+            raw_id = actor.split("::")[1]
+            clean_id = raw_id.split(" #")[0].strip()
+            actor_data:dict = get_vocab_entry("actors", clean_id) #type: ignore
+            return str(actor_data.get("name")) if isinstance(actor_data, dict) else clean_id
         
         return [_enrich_actor_name(str(actor.get("name"))) for actor in actors]
 

--- a/Engines/modules/documentation.py
+++ b/Engines/modules/documentation.py
@@ -130,8 +130,9 @@ def make_json_table(dataframe: pd.DataFrame) -> str:
         "sortable": "true"
     }
 
-    # Dumps as an escaped string
-    json_data = json.dumps(json_data)
+    # Dumps as a compact string — no whitespace separators, UTF-8 literals
+    # kept as-is to avoid multi-byte \uXXXX escape sequences inflating size
+    json_data = json.dumps(json_data, separators=(',', ':'), ensure_ascii=False)
 
     # Markdown block for rendering
     json_table = f"""
@@ -239,12 +240,14 @@ def backlink_resolver(model_uuid:str,
                         raw_link:bool=False,
                         raw_hover:bool=False,
                         hover_length:int=150,
+                        hover:bool=True,
                         current_page:Optional[str]=None):
     """
     Formats a markdown link to the model, using localized paths.
 
     raw_link: returns the raw link, without markdown link formatting
     raw_hover: in combination with raw_link, returns a tuple with the cursor hovering content
+    hover: when False, omits the title tooltip from the markdown link to reduce output size
     """
     model_type = get_type(model_uuid)
     file_link = backlink_name = icon = str()
@@ -258,7 +261,7 @@ def backlink_resolver(model_uuid:str,
         doc_path = "../" + DOCUMENTATION_CONFIG.object_names["dom"] + "/"
     else:
         doc_path = "../" + DOCUMENTATION_CONFIG.object_names[model_type] + "/"
-        hover = ""
+        hover_content = ""
 
     def mdr_statuses(mdr_id):
         mdr_configs = MODELS_INDEX["mdr"][mdr_id]["configurations"]
@@ -271,12 +274,12 @@ def backlink_resolver(model_uuid:str,
         return [f"[{s}] : {status}" for s, status in system_statuses.items()]
 
     if model_type == "tvm":
-        hover = model_value(model_uuid, "description")
+        hover_content = model_value(model_uuid, "description")
     if model_type == "cdm":
-        hover = model_value(model_uuid, "guidelines")
+        hover_content = model_value(model_uuid, "guidelines")
     if model_type == "dom":
         objective_data = DataTide.Models.DOM[model_uuid]
-        hover = objective_data.objective.description
+        hover_content = objective_data.objective.description
 
     if model_type == "signal":
         signal_data = DataTide.Models.Signal[model_uuid]
@@ -285,24 +288,24 @@ def backlink_resolver(model_uuid:str,
             # If we're on the current DOM page, we should just do an anchor and no need to add
             # the full context
             backlink_name = signal_data.name
-            hover = signal_data.description
-            file_link = f"#{signal_data.name.replace(" ", "-").lower()}"
+            hover_content = signal_data.description
+            file_link = f"#{signal_data.name.replace(' ', '-').lower()}"
 
         else:
             backlink_name = objective_data.name + "::" + signal_data.name
-            hover = signal_data.description
+            hover_content = signal_data.description
             # We point to the parent objective wiki page with an anchor to the signal name
-            file_link = objective_data.name + f"#{signal_data.name.replace(" ", "-").lower()}"
+            file_link = objective_data.name + f"#{signal_data.name.replace(' ', '-').lower()}"
     elif model_type == "mdr":
         model_name = model_data["name"]
 
         backlink_name = model_name.replace("_", " ")
-        hover = "&#013;&#010;".join(
+        hover_content = "&#013;&#010;".join(
             mdr_statuses(model_uuid)
-        ) 
+        )
         mdr_description = model_value(model_uuid, "description") or ""
         mdr_description = mdr_description
-        hover += f"&#013;&#010;&#013;&#010;{mdr_description}"
+        hover_content += f"&#013;&#010;&#013;&#010;{mdr_description}"
         file_link = f"{doc_path}{icon} {model_name}"
     else:
         model_name = model_data["name"].strip()
@@ -324,14 +327,17 @@ def backlink_resolver(model_uuid:str,
             file_link += ".md"
 
 
-    hover = sanitize_hover(str(hover))
-    if len(hover) > hover_length:
-        hover = hover[:hover_length] + "..."  
-    backlink = f"[{backlink_name}]({file_link} '{hover}')"
+    hover_text = sanitize_hover(str(hover_content))
+    if len(hover_text) > hover_length:
+        hover_text = hover_text[:hover_length] + "..."
+    if hover:
+        backlink = f"[{backlink_name}]({file_link} '{hover_text}')"
+    else:
+        backlink = f"[{backlink_name}]({file_link})"
     
     if raw_link:
         if raw_hover:
-            return file_link, hover
+            return file_link, hover_content
         return file_link
     
     return backlink

--- a/Engines/modules/documentation_components.py
+++ b/Engines/modules/documentation_components.py
@@ -69,7 +69,16 @@ def actors_doc(actors:list[dict])->str:
     for actor in actors:
         details = {}
         actor_name:str = actor.get("name", "")
-        actor_data:dict = get_vocab_entry("actors", actor_name.split("::")[1]) #type: ignore
+        # Strip inline comment annotations (e.g. "G0007 #[Mobile] APT28, ...")
+        # to obtain the bare vocabulary identifier (e.g. "G0007")
+        raw_identifier = actor_name.split("::")[1]
+        clean_identifier = raw_identifier.split(" #")[0].strip()
+        actor_data = get_vocab_entry("actors", clean_identifier)
+        if not isinstance(actor_data, dict):
+            log("WARNING",
+                f"Could not retrieve actor data for identifier [{clean_identifier}] — skipping actor",
+                actor_name)
+            continue
         details["Actor"] = actor_data.get("name")
         details["Description"] = str(actor_data.get("description")).replace("\n", "")
         details["Aliases"] = ", ".join(actor_data.get("alias", [])) #type: ignore

--- a/Engines/modules/graphs.py
+++ b/Engines/modules/graphs.py
@@ -240,7 +240,9 @@ def chaining_graph(tvm):
                     if type(data[0]) is dict:
                         clean_data = []
                         for actor in data:
-                            actor_name = get_vocab_entry("actors", actor.get("name").split("::")[1], "name")
+                            raw_id = actor.get("name").split("::")[1]
+                            clean_id = raw_id.split(" #")[0].strip()
+                            actor_name = get_vocab_entry("actors", clean_id, "name")
                             actor_name = actor_name.replace("[Enterprise]", "")
                             actor_name = actor_name.replace("[Mobile]", "")
                             actor_name = actor_name.replace("[ICS]", "")

--- a/Framework/Vocabulary/Alert Responders.yaml
+++ b/Framework/Vocabulary/Alert Responders.yaml
@@ -2,16 +2,39 @@ name: Alert Handling Team
 field: responders
 description: Team responsible to handle incoming security alerts 
 icon: ‍🚒
-keys:
-  - id: AHT0001
-    name: CATCH
-    description: Cybersecurity Analytics, Trending, Correlations & Hunting
-  - id: AHT0002
-    name: CSIRC
-    description: Computer Security Incident Response Centre
-  - id: AHT0003
-    name: MARTI
-    description: Malware Analysis, Research and Threat Intelligence
-  - id: AHT0004
-    name: S1-SA
-    description: Security Assurance and Vulnerability Management
+
+# ──────────────────────────────────────────────────────────────────────────────
+# INTENTIONALLY EMPTY — OpenTide instance-defined vocabulary
+# ──────────────────────────────────────────────────────────────────────────────
+# This vocabulary carries no built-in entries. Alert responder teams are
+# organisation-specific and must be defined locally by each OpenTide instance.
+#
+# HOW TO ADD YOUR TEAMS
+# ─────────────────────
+# Add entries via the [vocabulary] section of your OpenTide instance's
+# Configurations/schema.toml using the [[vocabulary.responders]] table array.
+#
+# Each entry requires:
+#   name        — short identifier used as the field value in MDR YAML files
+#   description — human-readable description of the team
+#
+# Optional fields:
+#   id          — stable identifier (recommended for traceability)
+#
+# Example:
+#
+#   [[vocabulary.responders]]
+#   id          = "AHT0001"
+#   name        = "SOC-T1"
+#   description = "First-line Security Operations Centre triage team"
+#
+#   [[vocabulary.responders]]
+#   id          = "AHT0002"
+#   name        = "CSIRT"
+#   description = "Computer Security Incident Response Team"
+#
+# Entries defined here will appear in VS Code autocomplete and JSON Schema
+# validation alongside any other vocabulary extensions.
+# ──────────────────────────────────────────────────────────────────────────────
+
+keys: []


### PR DESCRIPTION
## Summary

Follow-up improvements after BDR removal — hardens actor vocabulary lookups, reduces wiki page sizes, and delegates Alert Responders to downstream instances.

## Changes

### Actor identifier fix
- Strip inline comment annotations (e.g. `G0007 #[Mobile] APT28`) from actor vocabulary identifiers before lookup in `documentation_components.py`, `graphs.py`, `table_export.py`, and `wiki_navigation.py`
- Add graceful skip when actor data cannot be resolved

### Wiki performance
- Pass `hover=False` to `backlink_resolver` and `rich_attack_links` in navigation cover pages to reduce json:table output size
- Use compact JSON serialisation (`separators=(',', ':')`, `ensure_ascii=False`) for json:table markdown blocks
- Add `hover` parameter to `backlink_resolver` signature

### Alert Responders vocabulary delegation
- Empty the built-in Alert Responders vocabulary keys
- Add inline documentation explaining that teams are now instance-defined via `[[vocabulary.responders]]` in each OpenTide instance's `Configurations/schema.toml`

## Migration required (downstream instances)

Instances that previously relied on the built-in responder entries (CATCH, CSIRC, MARTI, S1-SA) must define them locally:

```toml
# Configurations/schema.toml

[[vocabulary.responders]]
id          = "AHT0001"
name        = "CATCH"
description = "Cybersecurity Analytics, Trending, Correlations and Hunting"

[[vocabulary.responders]]
id          = "AHT0002"
name        = "CSIRC"
description = "Computer Security Incident Response Centre"
```

EC-Tide already has this configuration in place.
