### PR TITLE
fix(metaschema): migrate CBC/Splunk to modern tenants spec

### DIFF
--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/CBC EDR Sub Schema.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/CBC EDR Sub Schema.yaml
@@ -28,13 +28,13 @@ properties:
       type: string
       format: email
 
-  organizations: 
-    title: Organizations
+  tenants: 
+    title: Target Tenants
     icon: 🏢
-    description: Override the default organizations the deployment will configure the reports onto.
+    description: Override the default tenants the deployment will configure the reports onto.
     type: array
     tide.template.hide: True
-    tide.config.parameter-list: systems.carbon_black_cloud.setup.organizations
+    tide.config.system.tenants: carbon_black_cloud
 
   watchlist: 
     title: Watchlist

--- a/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Splunk Sub Schema.yaml
+++ b/Framework/Meta Schemas/Sub Schemas/MDR Systems Deployment/Splunk Sub Schema.yaml
@@ -30,6 +30,14 @@ properties:
       type: string
       format: email
 
+  tenants: 
+    title: Target Tenants
+    icon: 🏢
+    description: Override the default tenants the deployment will target.
+    type: array
+    tide.template.hide: True
+    tide.config.system.tenants: splunk
+
   threshold: 
     title: Event threshold
     type: integer


### PR DESCRIPTION
Migrates Carbon Black Cloud and Splunk sub-schemas from the obsolete tide.config.parameter-list / missing tenants field to the modern tide.config.system.tenants directive, aligning them with the Sentinel pattern. Fixes empty enum validation error on CBC organizations field and adds multi-tenancy support to the Splunk sub-schema for MDRv4.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenTideHQ/codesmith/CoreTide/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785411319&installation_id=142135214&pr_number=89&repository=OpenTideHQ%2FCoreTide&return_to=https%3A%2F%2Fgithub.com%2FOpenTideHQ%2FCoreTide%2Fpull%2F89&signature=a0540b88159dbad7c98edae68305c1b3d8dfd545f01cb75e99b15189f73fdd71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->