### PR TITLE
fix(splunk): resolve typed MDRv4 modifiers in deploy_mdr_v4

### DIFF
--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -669,12 +669,29 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         if enable_correlation:
             name += " - Rule"
 
-        # Status modifiers
+        # Status modifiers — resolve from typed MDRv4 modifiers list
         status_allowed_actions = self.SPLUNK_ACTIONS
-        status_modifiers = (self.STATUS_MODIFIERS or {}).get(status) or {}
+        status_modifiers: dict = {}
+
+        if self.STATUS_MODIFIERS:
+            for mod in self.STATUS_MODIFIERS:
+                match = False
+                if mod.conditions.default and mod.conditions.default is True:
+                    match = True
+                if mod.conditions.status and status in mod.conditions.status:
+                    match = True
+                if mod.conditions.tenants:
+                    if tenant_config.name in mod.conditions.tenants:
+                        match = True
+                    else:
+                        match = False
+
+                if match:
+                    log("INFO", f"Modifier matched: {mod.name or 'unnamed'}",
+                        str(mod.conditions))
+                    status_modifiers.update(mod.modifications)
 
         if status_modifiers:
-            status_modifiers = dict(status_modifiers)
             if "allowed_actions" in status_modifiers:
                 allowed_actions_config = status_modifiers.pop("allowed_actions")
                 if allowed_actions_config in [False, None]:


### PR DESCRIPTION
deploy_mdr_v4 was using legacy dict-keyed .get(status) on STATUS_MODIFIERS which is now a typed Sequence[SystemConfig.Modifiers]. Refactors to iterate modifiers and match conditions (status/tenants/default) before applying — same pattern as TideDeployment.modifiers_resolver but at the savedsearches.conf config-dict level.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenTideHQ/codesmith/CoreTide/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785431688&installation_id=142135214&pr_number=91&repository=OpenTideHQ%2FCoreTide&return_to=https%3A%2F%2Fgithub.com%2FOpenTideHQ%2FCoreTide%2Fpull%2F91&signature=f51fe9c446f3c088dc4ce3856ba640c74ca74f25488b6533fc94285e1b3be411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->