### PR TITLE
fix(splunk): resolve lookback clobbering by Platform Defaults modifier

### DIFF
--- a/Engines/deployment/splunk.py
+++ b/Engines/deployment/splunk.py
@@ -1,11 +1,7 @@
-import os
 import git
 import sys
 import json
-from typing import Literal, Sequence
-from pprint import pprint
-
-import pandas as pd
+from typing import Sequence
 
 sys.path.append(str(git.Repo(".", search_parent_directories=True).working_dir))
 
@@ -13,12 +9,10 @@ from Engines.modules.splunk import (
     SplunkEngineInit,
     connect_splunk,
     cron_to_timeframe,
-    create_query,
     create_query_v4,
     splunk_timerange,
 )
 from Engines.modules.framework import (
-    get_value_metaschema,
     techniques_resolver,
 )
 from Engines.modules.logs import log
@@ -37,349 +31,7 @@ from Engines.modules.plugins import DeployMDR
 
 class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
-    def config_mdr(self, mdr):
-        """
-        Compiled the configuration that will be written to the saved search object.
-        """
-        # TODO: DEPRECATED [splunk-mdrv4] — Replace with config_mdr_v4() for splunk::3.0 MDRs
-
-        config = dict()
-
-        # Before processing MDR data, adding config configuration
-        uuid = mdr.get("uuid") or mdr["metadata"]["uuid"]
-        name = mdr["name"].strip()
-        description = mdr["description"]
-        mdr_splunk = mdr["configurations"]["splunk"]
-        advanced_config = mdr_splunk.pop(
-            "advanced", None
-        )  # Remove advanced config and keep it separate
-        
-        # Normalize all types to string by safety
-        if advanced_config:
-            advanced_config = {k: str(v) for k,v in advanced_config.items()}
-        
-        # Exception for risk, as is a particular data structure in Splunk
-        risk = mdr_splunk.get("risk")
-        if risk:
-            risk = mdr_splunk.pop("risk")
-
-        mdr_splunk = pd.json_normalize(mdr_splunk, sep="|").to_dict(orient="records")[0]
-        for key in mdr_splunk.copy():  # Avoids dict mutation errors
-            new_key = str(key).split("|")[
-                -1
-            ]  # type:ignore Keep only the string after the last separator
-            mdr_splunk[new_key] = mdr_splunk.pop(key)
-
-        for key in mdr_splunk:
-            param_name = get_value_metaschema(
-                key, self.SPLUNK_SUBSCHEMA, "tide.mdr.parameter"
-            )
-            data = mdr_splunk[key]
-
-            if key == "lookback":
-                data = splunk_timerange(
-                    data, skewing=self.SKEWING_VALUE, offset=self.OFFSET
-                )
-
-            if key == "duration":
-                config["alert.suppress"] = "true"
-
-            if key == "frequency":
-                # If there is no cron expression, we assign the parameter of cron on it which will deploy
-                if "cron" not in mdr_splunk:
-                    custom_time = mdr_splunk.get(
-                        "custom_time"
-                    )  # Check if there is a custom time the rule should trigger at
-                    if custom_time:
-                        data = cron_to_timeframe(
-                            data, mode="custom", custom_time=custom_time
-                        )
-                    else:
-                        data = cron_to_timeframe(data, mode=self.TIMERANGE_MODE)
-                    param_name = get_value_metaschema(
-                        "cron", self.SPLUNK_SUBSCHEMA, "tide.mdr.parameter"
-                    )
-
-            # Splunk mostly expects comma separated list when multiple values are present
-            if type(data) == list:
-                data = ", ".join(data)
-
-            if type(data) == str:
-                data = data.strip()
-
-            if param_name:
-                config[param_name] = data
-
-        # Disabled Check
-        status = mdr_splunk["status"]
-        if check_status(status) is StatusStrategy.DISABLEMENT:
-            config["disabled"] = "true"
-            log("INFO", "🔕 Configuring saved search as disabled")
-
-        # Alert Severity Configuration
-        config["alert.severity"] = self.ALERT_SEVERITY_MAPPING[
-            mdr["response"]["alert_severity"]
-        ]
-
-        # Risk action has a specific implementation in Splunk where it fully relies on a
-        # single flattened JSON string to represent the entire risk configuration. This is
-        # unique in Splunk and is most likely explained by the fact that risk is a list of dictionaries,
-        # which can't be represented in the flat key:value structure of savedsearches.conf
-        if risk:
-            risk_config = []
-            risk_param = get_value_metaschema(
-                "risk", self.SPLUNK_SUBSCHEMA, "tide.mdr.parameter"
-            )
-            risk_objects_config = []
-            threat_objects_config = []
-            risk_message = risk.get("message")
-            if ro := risk.get("risk_objects"):
-                for risk_object in ro:
-                    risk_object_paramed = {}
-                    for key in risk_object:
-                        risk_object_paramed[
-                            get_value_metaschema(
-                                key,
-                                self.SPLUNK_SUBSCHEMA,
-                                "tide.mdr.parameter",
-                                scope="risk_objects",
-                            )
-                        ] = risk_object[key]
-                    risk_objects_config.append(risk_object_paramed)
-
-            if to := risk.get("threat_objects"):
-                for threat_object in to:
-                    threat_object_paramed = {}
-                    for key in threat_object:
-                        threat_object_paramed[
-                            get_value_metaschema(
-                                key,
-                                self.SPLUNK_SUBSCHEMA,
-                                "tide.mdr.parameter",
-                                scope="threat_objects",
-                            )
-                        ] = threat_object[key]
-                    threat_objects_config.append(threat_object_paramed)
-
-            risk_config = risk_objects_config + threat_objects_config
-            if risk_config:
-                config[risk_param] = json.dumps(risk_config)
-            if risk_message:
-                config[
-                    get_value_metaschema(
-                        "message",
-                        self.SPLUNK_SUBSCHEMA,
-                        "tide.mdr.parameter",
-                        scope="risk",
-                    )
-                ] = risk_message
-
-        # If there are advanced configurations, add it to the otherall config
-        if advanced_config:
-            for adv in advanced_config:
-                config[adv] = advanced_config[adv]
-
-        # Add ManagedBy and set to responders
-        responders = mdr.get("response", {}).get("responders") or ""
-        config["alert.managedBy"] = responders
-
-        # Add correlation search setup
-        if self.CORRELATION_SEARCHES:
-            config["action.correlationsearch.enabled"] = "true"
-            # For compatibility with Splunk Enterprise Security post-processing on
-            # correlation searches, append " - Rule" to the correlation search label
-            config["action.correlationsearch.label"] = name + " - Rule"
-            techniques = techniques_resolver(uuid)
-            if techniques:
-                config["action.correlationsearch.annotations.mitre_attack"] = ", ".join(
-                    techniques
-                )
-
-        # Human readable description
-        config["description"] = description
-        return config
-
-    def deploy_mdr(self, mdr, service):
-        """
-        Deployment routine, connecting to the platform and combining base and custom configurations
-        """
-        # TODO: DEPRECATED [splunk-mdrv4] — Replace with deploy_mdr_v4() for splunk::3.0 MDRs
-
-        # Generate saved search configuration
-        mdr_config = self.config_mdr(mdr)
-
-        # Fetch name for the saved search
-        name: str = mdr["name"].strip()
-        if self.CORRELATION_SEARCHES:
-            # For compatibility with Splunk Enterprise Security post-processing on
-            # correlation searches, append " - Rule" to the saved search name
-            name += " - Rule"
-
-        mdr_splunk: dict = mdr["configurations"]["splunk"]
-        status: str = mdr_splunk["status"]
-        query = create_query(mdr)
-
-        # By default, status allows all the actions supported by the global config
-        status_allowed_actions = self.SPLUNK_ACTIONS
-
-        # Add status specific parameters
-        status_modifiers = self.STATUS_MODIFIERS.get(status) or {}
-
-        if status_modifiers:
-            if "allowed_actions" in status_modifiers:
-                allowed_actions_config = status_modifiers.pop("allowed_actions")
-                # If explicitely set to False, we blank the actions allowed
-                if allowed_actions_config in [False, None]:
-                    log(
-                        "INFO",
-                        "This MDR will not have any action enabled in Splunk, as actions_enabled is set to False",
-                        status,
-                    )
-                    status_allowed_actions = []
-                else:
-                    log(
-                        "INFO",
-                        "The enabled actions for this MDR will be constrained by the status modifier actions_enabled",
-                        allowed_actions_config,
-                    )
-                    status_allowed_actions = allowed_actions_config
-
-            # We pop out allowed_actions, remainder are attributes
-            if status_modifiers:
-                log(
-                    "INFO",
-                    f"Applying status modifiers for {status}",
-                    str(status_modifiers),
-                )
-                mdr_config.update(status_modifiers)
-
-        actions_config = {}
-
-        # Add allowed splunk actions once the entire MDR is configured
-        if self.SPLUNK_ACTIONS:
-            # We enable the action only when a configuration has been set related to this action
-            # For example, we may allow action.email, but will only configure it as enabled
-            # if some parameter in the config related to it were configured
-            triggered_actions = []
-            for action in self.SPLUNK_ACTIONS:
-                for param in mdr_config:
-                    if "action." + action in param:
-                        if action in status_allowed_actions:
-                            triggered_actions.append(action)
-                            actions_config["action." + action] = (
-                                1  # Turning on the action
-                            )
-                            break
-
-            if not triggered_actions:
-                # Allowing default actions if they are not denied at status config level
-                triggered_actions = [
-                    action
-                    for action in self.SPLUNK_DEFAULT_ACTIONS
-                    if action in status_allowed_actions
-                ]
-
-            if triggered_actions:
-                actions_config["actions"] = ", ".join(triggered_actions)
-
-                # Actions modifiers which automate certain attributes bound to the action being allocated
-                if "notable" in triggered_actions:
-                    # Assign default notable title if not specified in mdr config
-                    if "action.notable.param.rule_title" not in mdr_config:
-                        actions_config["action.notable.param.rule_title"] = name
-                        actions_config["action.notable.param.rule_description"] = (
-                            mdr.get("description") or ""
-                        )
-                        actions_config["action.notable.param.severity"] = mdr[
-                            "response"
-                        ]["alert_severity"].lower()
-                        
-                    # Ensuring security domain is lowercased
-                    if  security_domain:=mdr_config.get("action.notable.param.security_domain"):
-                        mdr_config["action.notable.param.security_domain"] = security_domain.lower()
-                if "risk" in triggered_actions:
-                    # Explicitely set _risk_score to 0 since it is set to 1 by the platform
-                    # as a way to show a default GUI, but interferes with automation.
-                    # All risk configuration are carried by action.notable.param._risk in a JSON bundle
-                    actions_config["action.risk.param._risk_score"] = 0
-
-            else:
-                actions_config["actions"] = ""
-
-        deploy_config = self.DEFAULT_CONFIG.copy()
-        deploy_config.update(mdr_config)
-        deploy_config.update(actions_config)
-        deploy_config["search"] = query
-
-        log("INFO", "The following configuration was compiled")
-        print(json.dumps(deploy_config, indent=1, sort_keys=True))
-
-        # In Splunk, some configurations are coupled with others. The update()
-        # method of saved_searches objects does not resolve this, and depending on the
-        # order of the attrributes in the kwargs passed may hit blocks.
-        #
-        # This workaround lifts some of those identified blockers and will roll them out
-        # after their dependencies, which are deployed first.
-
-        second_stage_attributes = [
-            "alert.suppress",  # needs alert.suppress.period to be set first
-            "is_scheduled",  # needs alert_comparator to be set first
-            "actions",  # requires other action namespace item to be set first
-            "search",  # empirical testing show that the search don't update properly if not last
-        ]
-        second_stage = dict()
-
-        for attribute in second_stage_attributes:
-            if attribute in deploy_config:
-                second_stage[attribute] = deploy_config.pop(attribute)
-
-        # Check if saved search already exists or create a new one
-        try:
-            selected_search = service.saved_searches[name]
-            log("INFO", "Found existing saved search", name)
-        except:
-            # Special case for removed rules, do not bother with recreating
-            if check_status(status) is StatusStrategy.DELETION:
-                log(
-                    "SKIP",
-                    f"Saved search was already non existent, no action required",
-                    name
-                )
-                return None
-
-            # For all other rules, create a new saved search
-            else:
-                log("ONGOING", "Will create a new saved search", name)
-                selected_search = service.saved_searches.create(name, search=query)
-
-        # Steps to handle REMOVED rules
-        if check_status(status) is StatusStrategy.DELETION:
-            service.saved_searches.delete(name)
-            log("WARNING", f"Deleted splunk alert", name)
-            return None
-
-        # Debugging output; sets attribute one by one
-        if self.DEBUG_STEP:
-            for k, v in deploy_config.items():
-                log("ONGOING", f"Updating value {k} with {v}")
-                selected_search.update(**{k: v})
-
-            if second_stage:
-                for k, v in second_stage.items():
-                    log("ONGOING", f"Updating value {k} with {v}")
-                    selected_search.update(**{k: v})
-
-        else:
-            selected_search.update(**deploy_config)
-
-            # Rolling out attributes with dependencies that will block the deployment if out of order.
-            if second_stage:
-                selected_search.update(**second_stage)
-        log("SUCCESS", "Deployed on Splunk", name)
-
-        return True
-
-    # ─── MDRv4 typed methods ───────────────────────────────────────────
+    # ─── Configuration builder ────────────────────────────────────────
 
     def _should_enable_correlation_search(
         self,
@@ -410,15 +62,19 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
             return es_enabled
         return True
 
-    def config_mdr_v4(
+    def config_mdr(
         self,
         data: TideModels.MDR,
         tenant_setup: TideConfigs.Systems.Splunk.Tenant.Setup,
     ) -> dict:
         """Build the savedsearches.conf attribute dict from a typed MDR object.
 
-        This replaces the pandas json_normalize approach used in v3 with direct
-        typed attribute access.
+        Translates the typed MDR Splunk configuration into a flat dictionary of
+        Splunk saved search attributes ready for deployment via splunklib.
+
+        Modifiers are resolved centrally by TideDeployment.modifiers_resolver()
+        before this method is called — the MDR object received here already
+        incorporates all modifier transformations.
         """
         config: dict = {}
 
@@ -643,13 +299,27 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
         return config
 
-    def deploy_mdr_v4(
+    # ─── Single MDR deployment ────────────────────────────────────────
+
+    def deploy_mdr(
         self,
         data: TideModels.MDR,
         service,
         tenant_config: TideConfigs.Systems.Splunk.Tenant,
     ):
-        """Deploy a single typed MDR to Splunk, handling create/update/delete."""
+        """Deploy a single typed MDR to Splunk, handling create/update/delete.
+
+        The MDR received here has already been processed by the central
+        TideDeployment.modifiers_resolver() — all modifier transformations
+        (defaults, status-based overrides, tenant scoping) are already applied
+        to the typed MDR object (scheduling, trigger, actions, etc.).
+
+        However, modifiers may also carry flat Splunk savedsearches.conf attributes
+        (e.g. ``dispatch.latest_time``, ``alert.severity``) that don't map to the
+        typed dataclass. These are resolved here using correct precedence:
+        - Default modifiers (``default=true``) fill gaps only
+        - Status/tenant modifiers override unconditionally
+        """
 
         splunk_config = data.configurations.splunk
         if not splunk_config:
@@ -657,7 +327,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
             return None
 
         tenant_setup = tenant_config.setup
-        mdr_config = self.config_mdr_v4(data, tenant_setup)
+        mdr_config = self.config_mdr(data, tenant_setup)
 
         name = data.name.strip()
         status = splunk_config.status
@@ -669,14 +339,22 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         if enable_correlation:
             name += " - Rule"
 
-        # Status modifiers — resolve from typed MDRv4 modifiers list
+        # ── Modifier-driven flat attributes ───────────────────────────
+        # The central modifiers_resolver handles typed fields (scheduling,
+        # trigger, etc.) at the MDR object level. But modifiers also carry
+        # flat Splunk attributes (dispatch.latest_time, alert.severity, etc.)
+        # that only make sense at the savedsearches.conf level.
+        # Resolve them here with correct precedence.
         status_allowed_actions = self.SPLUNK_ACTIONS
-        status_modifiers: dict = {}
+        default_attributes: dict = {}
+        override_attributes: dict = {}
 
         if self.STATUS_MODIFIERS:
             for mod in self.STATUS_MODIFIERS:
                 match = False
-                if mod.conditions.default and mod.conditions.default is True:
+                is_default = mod.conditions.default is True
+
+                if is_default:
                     match = True
                 if mod.conditions.status and status in mod.conditions.status:
                     match = True
@@ -689,23 +367,37 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
                 if match:
                     log("INFO", f"Modifier matched: {mod.name or 'unnamed'}",
                         str(mod.conditions))
-                    status_modifiers.update(mod.modifications)
+                    if is_default:
+                        default_attributes.update(mod.modifications)
+                    else:
+                        override_attributes.update(mod.modifications)
 
-        if status_modifiers:
-            if "allowed_actions" in status_modifiers:
-                allowed_actions_config = status_modifiers.pop("allowed_actions")
+        # Handle allowed_actions directive (deployment control, not a Splunk attr)
+        for attrs in (default_attributes, override_attributes):
+            if "allowed_actions" in attrs:
+                allowed_actions_config = attrs.pop("allowed_actions")
                 if allowed_actions_config in [False, None]:
-                    log("INFO", "Actions will be suppressed for this MDR", status)
+                    log("INFO", "Actions suppressed by modifier directive", status)
                     status_allowed_actions = []
-                else:
+                elif isinstance(allowed_actions_config, list):
                     status_allowed_actions = allowed_actions_config
 
-            if status_modifiers:
-                log("INFO", f"Applying status modifiers for {status}", str(status_modifiers))
-                mdr_config.update(status_modifiers)
+        # Apply defaults (fill gaps only — never overwrite rule-specific values)
+        for k, v in default_attributes.items():
+            if k not in mdr_config:
+                mdr_config[k] = v
 
-        # Actions enablement
+        # Apply overrides (always take precedence)
+        if override_attributes:
+            log("INFO", f"Applying override modifiers for {status}",
+                str(override_attributes))
+            mdr_config.update(override_attributes)
+
+        # ── Actions enablement ────────────────────────────────────────
+        # Platform-specific logic: determine which Splunk actions to enable
+        # based on what action parameters are present in the config.
         actions_config: dict = {}
+
         if self.SPLUNK_ACTIONS:
             triggered_actions = []
             for action in self.SPLUNK_ACTIONS:
@@ -743,7 +435,8 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
             else:
                 actions_config["actions"] = ""
 
-        deploy_config = (self.DEFAULT_CONFIG or {}).copy()
+        # ── Assemble final deploy config ──────────────────────────────
+        deploy_config: dict = {}
         deploy_config.update(mdr_config)
         deploy_config.update(actions_config)
         deploy_config["search"] = query
@@ -751,7 +444,10 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         log("INFO", "The following configuration was compiled")
         print(json.dumps(deploy_config, indent=1, sort_keys=True, default=str))
 
-        # Two-stage attribute deployment
+        # ── Two-stage attribute deployment ────────────────────────────
+        # In Splunk, some configurations are coupled with others. The update()
+        # method of saved_searches objects does not resolve this, and depending
+        # on the order of the attributes in the kwargs passed may hit blocks.
         second_stage_attributes = [
             "alert.suppress",
             "is_scheduled",
@@ -763,7 +459,7 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
             if attribute in deploy_config:
                 second_stage[attribute] = deploy_config.pop(attribute)
 
-        # Check if saved search exists or create
+        # ── Create or locate saved search ─────────────────────────────
         try:
             selected_search = service.saved_searches[name]
             log("INFO", "Found existing saved search", name)
@@ -775,13 +471,13 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
                 log("ONGOING", "Will create a new saved search", name)
                 selected_search = service.saved_searches.create(name, search=query)
 
-        # Handle REMOVED rules
+        # ── Handle REMOVED rules ──────────────────────────────────────
         if check_status(status) is StatusStrategy.DELETION:
             service.saved_searches.delete(name)
             log("WARNING", f"Deleted splunk alert", name)
             return None
 
-        # Deploy
+        # ── Write to Splunk ───────────────────────────────────────────
         if self.DEBUG_STEP:
             for k, v in deploy_config.items():
                 log("ONGOING", f"Updating value {k} with {v}")
@@ -798,13 +494,20 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
         log("SUCCESS", "Deployed on Splunk", name)
         return True
 
-    # ─── Legacy MDRv3 deploy ──────────────────────────────────────────
+    # ─── Interface: DeployMDR.deploy() ────────────────────────────────
+
     def deploy(
         self,
         mdr_deployment: Sequence[TideModels.MDR] | list[str],
         deployment_plan: DeploymentStrategy,
     ):
-        """Deploy Splunk MDRs via MDRv4 typed deployment path."""
+        """Deploy Splunk MDRs through the central TideDeployment framework.
+
+        This is the DeployMDR interface implementation. It delegates modifier
+        resolution, tenant routing, and deployment strategy to the central
+        TideDeployment framework, then handles platform-specific Splunk API
+        interactions for each resolved MDR.
+        """
 
         self.configure_proxy()
 
@@ -842,14 +545,16 @@ class SplunkDeploy(SplunkEngineInit, DeployMDR):
 
             for mdr in tenant_deployment.rules:
                 log("ONGOING", "Processing rule", mdr.name, mdr.metadata.uuid)
-                self.deploy_mdr_v4(
+                self.deploy_mdr(
                     data=mdr,
                     service=service,
                     tenant_config=tenant,
                 )
 
+
 def declare():
     return SplunkDeploy()
+
 
 if __name__ == "__main__" and DebugEnvironment.ENABLED:
     SplunkDeploy().deploy(


### PR DESCRIPTION
## Problem

Every Splunk-deployed rule with a `scheduling.lookback` value was running against **All time** instead of the configured time window.

**Reported by:** CSIRC flagged excessive alerts. Investigation showed YAML specifies `1h schedule / 2h lookback` but Splunk ES had `1h schedule / no lookback` (All time).

## Root Cause

The `deploy_mdr_v4` method duplicated modifier resolution inline instead of relying on the central `TideDeployment.modifiers_resolver()`. The Platform Defaults modifier (`default=true`) contains `dispatch.earliest_time = ""` which was applied via a flat `dict.update()` — overwriting the correctly computed lookback value with an empty string.

Default modifiers and status overrides were conflated with identical precedence.

## Fix

- **Remove legacy v3 dead code** (`config_mdr`/`deploy_mdr` operating on raw dicts + pandas)
- **Remove pandas dependency** from the deployer
- **Rename** `config_mdr_v4` -> `config_mdr`, `deploy_mdr_v4` -> `deploy_mdr`
- **Fix modifier precedence**: defaults fill gaps only (`if k not in mdr_config`), status overrides always win
- **Preserve** `dispatch.latest_time` and other useful Platform Default values for rules that don't explicitly set them

## Scope

This affects **all Splunk-deployed rules with a `lookback` value** — not a one-off. Net result: -295 lines.

## Testing

Trace-verified with example MDR (`RBA_RR - Protected Branch Settings Changed.yaml`, status ACCEPTANCE, lookback 2h):
- `config_mdr()` correctly sets `dispatch.earliest_time = -144m@m`
- Platform Defaults modifier matches but `dispatch.earliest_time` is skipped (already set)
- `dispatch.latest_time = -5m@m` applied as gap-fill (not in rule config)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/OpenTideHQ/codesmith/CoreTide/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785488325&installation_id=142135214&pr_number=92&repository=OpenTideHQ%2FCoreTide&return_to=https%3A%2F%2Fgithub.com%2FOpenTideHQ%2FCoreTide%2Fpull%2F92&signature=6a6a5ca727eb736d57de6684ce75476603a66dff9f1ed2dd22bd47878f4e9293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->